### PR TITLE
Support custom regex and configurable single version rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 ===
 
+0.4.0
+---
+
+* Add a `vertagus init` command that runs a wizard to create a vertagus configuration file.
+- Add support for configurable rules for single-version rule evaluation.
+- Add a `custom_regex` rule that can be configured in the vertagus config to provide user-defined regex validation.
+
+
 0.3.1
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ project:
   rules:
     current:
       - not_empty
+      - type: custom_regex
+        config:
+          pattern: '^1.+'
     increment:
       - any_increment
   manifests:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,19 +68,32 @@ project:
 
 ### Built-in Rules
 
-#### Current Version Rules
+You can see which rules are pre-defined in vertagus by running the command:
 
-- `not_empty` - Version string must not be empty
-- `regex_mmp` - Standard major.minor.patch format (e.g., "1.0.0")
-- `regex_dev_mmp` - Development versions (e.g., "1.0.0.dev0")
-- `regex_beta_mmp` - Beta versions (e.g., "1.0.0.b0")
+```
+vertagus list-rules
+```
 
-#### Increment Rules
+The output of this command will be a list of rules, their descriptions, as well as whether the rule
+is intended as an `increment` rule (in which the current working version is compared to the highest one in source control) or as a
+`current` rule, which can be run against the current working version by itself.
 
-- `any_increment` - Any version increment is allowed
-- `major_increment` - Only major version increments
-- `minor_increment` - Only minor version increments  
-- `patch_increment` - Only patch version increments
+### Configurable rules
+
+Configurable rules are rules that accept configuration values. Vertagus currently supports a single configurable rule, `custom_regex`. 
+While other non-configurable rules can be listed by name in the vertagus config, configurable rules should be listed as an object with
+`type` and `config` fields. For example, the following combination is a configurable rule that enforces semantic versioning with a 
+built in rule, but also uses a configurable rule to enforce that the major component of the version must be `1`:
+
+```yaml
+project:
+  rules:
+    current:
+      - regex_mmp
+      - type: custom_regex
+        config:
+          pattern: '^1.+'
+```
 
 ## Stage Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vertagus"
-version = "0.4.0.dev1"
+version = "0.4.0.dev2"
 description = "A tool to assist the maintenance of package versioning via manifests and source control."
 readme = "README.md"
 authors = [

--- a/src/vertagus/cli/commands/list_rules.py
+++ b/src/vertagus/cli/commands/list_rules.py
@@ -1,13 +1,13 @@
 import click
 
 from vertagus.rules.comparison.loader import get_rules as get_comparison_rules, VersionComparisonRule
-from vertagus.rules.single_version.loader import get_rules as get_single_version_rules, SingleVersionRule
+from vertagus.rules.single_version.loader import get_rules as get_single_version_rules, SingleVersionRuleType
 from vertagus.cli.formatting import DisplayTableFormatter
 
 
 @click.command("list-rules")
 def list_rules_cmd():
-    single_version_rules: list[type[SingleVersionRule]] = get_single_version_rules()
+    single_version_rules: list[SingleVersionRuleType] = get_single_version_rules()
     comparison_rules: list[type[VersionComparisonRule]] = [
         r for r in get_comparison_rules() if r.name != "manifests_comparison"
     ]

--- a/src/vertagus/configuration/types.py
+++ b/src/vertagus/configuration/types.py
@@ -16,6 +16,11 @@ def getdefault(d: DictType, k: str, default: V) -> V:
     return r
 
 
+class TypeAndConfig(T.TypedDict):
+    type: str
+    config: dict  
+
+
 class ScmConfigBase(T.TypedDict):
     type: str
     version_strategy: T.Optional[T.Literal["tag", "branch"]]
@@ -54,7 +59,7 @@ class ManifestComparisonConfig(T.TypedDict):
 
 
 class RulesConfig(T.TypedDict):
-    current: list[str]
+    current: list[str] | TypeAndConfig
     increment: list[str]
     manifest_comparisons: list[ManifestComparisonConfig]
 

--- a/src/vertagus/configuration/types.py
+++ b/src/vertagus/configuration/types.py
@@ -59,7 +59,7 @@ class ManifestComparisonConfig(T.TypedDict):
 
 
 class RulesConfig(T.TypedDict):
-    current: list[str] | TypeAndConfig
+    current: T.Union[list[str], TypeAndConfig]
     increment: list[str]
     manifest_comparisons: list[ManifestComparisonConfig]
 

--- a/src/vertagus/core/package_base.py
+++ b/src/vertagus/core/package_base.py
@@ -1,15 +1,16 @@
 import typing as T
 from vertagus.core.manifest_base import ManifestBase
-from vertagus.core.rule_bases import SingleVersionRule, VersionComparisonRule
+from vertagus.rules.comparison.library import ManifestsComparisonRule
+from vertagus.core.rule_bases import SingleVersionRuleProtocol, VersionComparisonRule
 
 
 class Package:
     def __init__(
         self,
         manifests: list[ManifestBase],
-        current_version_rules: list[T.Type[SingleVersionRule]],
+        current_version_rules: list[SingleVersionRuleProtocol],
         version_increment_rules: list[VersionComparisonRule],
-        manifest_versions_comparison_rules: T.Sequence[VersionComparisonRule],
+        manifest_versions_comparison_rules: T.Sequence[ManifestsComparisonRule],
     ):
         self._manifests = manifests or []
         self._current_version_rules = current_version_rules or []

--- a/src/vertagus/core/project.py
+++ b/src/vertagus/core/project.py
@@ -1,8 +1,9 @@
 import typing as T
 from logging import getLogger
+from copy import copy
 
 from vertagus.core.manifest_base import ManifestBase
-from vertagus.core.rule_bases import SingleVersionRule, VersionComparisonRule
+from vertagus.core.rule_bases import SingleVersionRuleProtocol, VersionComparisonRule
 from vertagus.rules.comparison.library import ManifestsComparisonRule
 from vertagus.core.tag_base import AliasBase
 from vertagus.core.bumper_base import BumperBase
@@ -24,7 +25,7 @@ class Project(Package):
     def __init__(
         self,
         manifests: list[ManifestBase],
-        current_version_rules: list[T.Type[SingleVersionRule]],
+        current_version_rules: list[SingleVersionRuleProtocol],
         version_increment_rules: list[VersionComparisonRule],
         manifest_versions_comparison_rules: list[ManifestsComparisonRule],
         stages: T.Optional[list[Stage]] = None,
@@ -138,7 +139,7 @@ class Project(Package):
             manifests.extend(stage.manifests)
         return list(dict.fromkeys(manifests).keys())
 
-    def _get_current_version_rules(self, stage_name=None) -> list[SingleVersionRule]:
+    def _get_current_version_rules(self, stage_name=None) -> list[SingleVersionRuleProtocol]:
         rules = self._current_version_rules.copy()
         if stage_name:
             stage = self._get_stage(stage_name)
@@ -153,7 +154,7 @@ class Project(Package):
         return list(dict.fromkeys(rules).keys())
 
     def _get_manifest_versions_comparison_rules(self, stage_name=None) -> list[ManifestsComparisonRule]:
-        rules = self._manifest_versions_comparison_rules.copy()
+        rules = list(copy(self._manifest_versions_comparison_rules))
         if stage_name:
             stage = self._get_stage(stage_name)
             rules.extend(stage.manifest_versions_comparison_rules)

--- a/src/vertagus/core/rule_bases.py
+++ b/src/vertagus/core/rule_bases.py
@@ -22,3 +22,31 @@ class SingleVersionRule(Rule):
     @classmethod
     def validate_version(cls, version: str):
         raise NotImplementedError("Method validate must be implemented in subclass")
+
+
+class ConfigurableSingleVersionRule(Rule):
+
+    def __init__(self, config: dict):
+        self.config = config
+    
+    def validate_version(self, version: str):
+        raise NotImplementedError("Method validate must be implemented in subclass")
+
+
+SingleVersionRuleType = T.Union[
+    T.Type[SingleVersionRule],
+    T.Type[ConfigurableSingleVersionRule],
+]
+
+SingleVersionRuleProtocol = T.Union[
+    T.Type[SingleVersionRule],
+    ConfigurableSingleVersionRule,
+]
+
+def is_single_version_rule_type(obj: T.Any) -> bool:
+    return isinstance(obj, type) and issubclass(obj, (SingleVersionRule, ConfigurableSingleVersionRule))
+
+def is_configurable_single_version_rule(obj: T.Any) -> bool:
+    return isinstance(obj, ConfigurableSingleVersionRule) or (
+        isinstance(obj, type) and issubclass(obj, ConfigurableSingleVersionRule)
+    )

--- a/src/vertagus/core/stage.py
+++ b/src/vertagus/core/stage.py
@@ -1,6 +1,6 @@
 import typing as T
 from vertagus.core.manifest_base import ManifestBase
-from vertagus.core.rule_bases import SingleVersionRule, VersionComparisonRule
+from vertagus.core.rule_bases import SingleVersionRuleProtocol, VersionComparisonRule
 from vertagus.rules.comparison.library import ManifestsComparisonRule
 from vertagus.core.tag_base import AliasBase
 from vertagus.core.bumper_base import BumperBase
@@ -12,7 +12,7 @@ class Stage(Package):
         self,
         name: str,
         manifests: list[ManifestBase],
-        current_version_rules: list[T.Type[SingleVersionRule]],
+        current_version_rules: list[SingleVersionRuleProtocol],
         version_increment_rules: list[VersionComparisonRule],
         manifest_versions_comparison_rules: list[ManifestsComparisonRule],
         aliases: T.Optional[list[type[AliasBase]]] = None,

--- a/src/vertagus/rules/comparison/library.py
+++ b/src/vertagus/rules/comparison/library.py
@@ -20,7 +20,7 @@ class ManifestsComparisonRule(VersionComparisonRule):
     def __init__(self, config: dict):
         self.manifest_names = config["manifests"]
 
-    def validate_comparison(self, versions: tuple[str, str]):
+    def validate_comparison(self, versions: list[str]):
         if not versions:
             raise ValueError("No versions to compare.")
         if len(versions) == 1:

--- a/src/vertagus/rules/single_version/library.py
+++ b/src/vertagus/rules/single_version/library.py
@@ -1,5 +1,5 @@
 import re
-from vertagus.core.rule_bases import SingleVersionRule
+from vertagus.core.rule_bases import SingleVersionRule, ConfigurableSingleVersionRule
 from vertagus.utils import regex as regex_utils
 
 
@@ -32,8 +32,23 @@ class RegexRuleBase(SingleVersionRule):
         return bool(re.match(cls.pattern, version))
 
 
-# Major-Minor-Patch Regex Rules
+class CustomRegexRule(ConfigurableSingleVersionRule):
 
+    name = "custom_regex"
+
+    def __init__(self, config: dict):
+        self.pattern = config.get("pattern", "")
+        if not self.pattern:
+            raise ValueError("Pattern must be provided in the configuration.")
+
+    def validate_version(self, version: str) -> bool:
+        return bool(re.match(self.pattern, version))
+
+    @classproperty
+    def description(cls):
+        return "Custom regex rule. Version must match a user-defined pattern."
+
+# Major-Minor-Patch Regex Rules
 
 class RegexMmp(RegexRuleBase):
     name = "regex_mmp"

--- a/src/vertagus/rules/single_version/loader.py
+++ b/src/vertagus/rules/single_version/loader.py
@@ -1,21 +1,21 @@
 import typing as T
 from . import library
-from vertagus.core.rule_bases import SingleVersionRule
+from vertagus.core.rule_bases import SingleVersionRuleType, is_single_version_rule_type
 
 
-def load_rules() -> list[T.Type[SingleVersionRule]]:
+def load_rules() -> list[SingleVersionRuleType]:
     _rules = []
     for objname in dir(library):
         maybeobj = getattr(library, objname)
-        if isinstance(maybeobj, type) and issubclass(maybeobj, SingleVersionRule):
-            obj: T.Type[SingleVersionRule] = maybeobj
+        if is_single_version_rule_type(maybeobj):
+            obj: SingleVersionRuleType = maybeobj
             if obj.name != "base":
                 _rules.append(obj)
     return _rules
 
 
-def get_rules(rule_names=None) -> list[T.Type[SingleVersionRule]]:
-    rules: list[T.Type[SingleVersionRule]] = load_rules()
+def get_rules(rule_names=None) -> list[SingleVersionRuleType]:
+    rules: list[SingleVersionRuleType] = load_rules()
     if rule_names is None:
         rule_names = [rule.name for rule in rules]
     not_found = set(rule_names) - {rule.name for rule in rules}

--- a/test/core/test_project.py
+++ b/test/core/test_project.py
@@ -3,11 +3,15 @@ import typing as T
 from unittest.mock import patch, MagicMock
 
 import pytest
+from vertagus.core.rule_bases import (
+    SingleVersionRuleProtocol,
+    SingleVersionRule,
+    ConfigurableSingleVersionRule,
+    VersionComparisonRule
+)
 from vertagus.core.project import (
     Project,
     ManifestBase,
-    SingleVersionRule,
-    VersionComparisonRule,
     ManifestsComparisonRule,
     Stage
 )
@@ -43,12 +47,21 @@ def mock_current_version_rule_pass():
             return True
     return MockCurrentVersionRulePass
 
+@pytest.fixture
+def mock_configurable_current_version_rule_pass():
+    class MockConfigurableCurrentVersionRulePass(ConfigurableSingleVersionRule):
+        name = "mock_configurable_current_version_rule"
+        def validate_version(self, version: str):
+            return True
+    return MockConfigurableCurrentVersionRulePass({"key": "value"})
+
 
 @pytest.fixture
 def mock_current_version_rules(
-    mock_current_version_rule_pass
-):
-    return [mock_current_version_rule_pass]
+    mock_current_version_rule_pass,
+    mock_configurable_current_version_rule_pass
+) -> list[SingleVersionRuleProtocol]:
+    return [mock_current_version_rule_pass, mock_configurable_current_version_rule_pass]
 
 
 @pytest.fixture
@@ -153,9 +166,9 @@ def mock_stage_with_alias(mock_manifests,
 
 @pytest.fixture
 def test_project(mock_manifests: list[ManifestBase],
-                 mock_current_version_rules: list[T.Type[SingleVersionRule]],
+                 mock_current_version_rules: list[SingleVersionRuleProtocol],
                  mock_version_increment_rules: list[T.Type[VersionComparisonRule]],
-                 mock_manifest_versions_comparison_rules: list[T.Type[VersionComparisonRule]],
+                 mock_manifest_versions_comparison_rules: list[T.Type[ManifestsComparisonRule]],
                  mock_stage: Stage
                  ):
     return Project(

--- a/test/core/test_stage.py
+++ b/test/core/test_stage.py
@@ -3,10 +3,9 @@ import typing as T
 import pytest
 from unittest.mock import patch, MagicMock
 from vertagus.core import stage
+from vertagus.core.rule_bases import SingleVersionRule, VersionComparisonRule
 from vertagus.core.stage import (
     ManifestBase,
-    SingleVersionRule,
-    VersionComparisonRule,
     ManifestsComparisonRule,
     Stage
 )

--- a/test/rules/single_version/test_sv_library.py
+++ b/test/rules/single_version/test_sv_library.py
@@ -2,7 +2,8 @@ import pytest
 from vertagus.rules.single_version.library import (
     SingleVersionRule,
     NotEmpty, RegexMmp, RegexDevMmp, RegexBetaMmp, RegexRcMmp, RegexAlphaMmp,
-    RegexMm, RegexDevMm, RegexBetaMm, RegexRcMm, RegexAlphaMm
+    RegexMm, RegexDevMm, RegexBetaMm, RegexRcMm, RegexAlphaMm,
+    CustomRegexRule
 )
 from vertagus.utils import regex as regex_utils
 
@@ -50,3 +51,14 @@ def test_version_validators(validator: SingleVersionRule,
 def test_validator_description():
     assert RegexMmp().description == f"Version must match the pattern: {regex_utils.patterns['mmp']}"
     assert NotEmpty().description == "Version must not be empty."
+
+@pytest.mark.parametrize(
+    ["pattern", "version", "expected"], [
+    (r"^\d+\.\d+\.\d+$", "1.0.0", True),
+    (r"^\d+\.\d+\.\d+$", "1.0", False),
+    (r"^\d+\.\d+\.\d+-dev\.\d+$", "1.0.0-dev.1", True),
+    (r"^\d+\.\d+\.\d+-dev\.\d+$", "1.0.0", False),
+])
+def test_custom_regex_rule(pattern: str, version: str, expected: bool):
+    rule = CustomRegexRule({"pattern": pattern})
+    assert rule.validate_version(version) == expected

--- a/test/rules/single_version/test_sv_loader.py
+++ b/test/rules/single_version/test_sv_loader.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from vertagus.core.rule_bases import SingleVersionRule
 from vertagus.rules.single_version import loader as sv_loader
 
 
@@ -10,7 +11,7 @@ def test_load_rules(library: MagicMock):
     class MockRuleNoSubclass:
         name = "mock_rule_no_subclass"
 
-    class MockRuleYesSubclass(sv_loader.SingleVersionRule):
+    class MockRuleYesSubclass(SingleVersionRule):
         name = "mock_rule_yes_subclass"
     
     library.MockRuleNoSubclass = MockRuleNoSubclass
@@ -30,7 +31,7 @@ def test_load_rules(library: MagicMock):
 @patch('vertagus.rules.single_version.loader.load_rules')
 def test_get_rules(load_rules: MagicMock):
 
-    class MockRule(sv_loader.SingleVersionRule):
+    class MockRule(SingleVersionRule):
         name = "mock_rule"
     
     load_rules.return_value = [MockRule]

--- a/test/test_factory.py
+++ b/test/test_factory.py
@@ -11,7 +11,6 @@ class DummyManifest:
     def __init__(self, **kwargs):
         pass
 
-
     
 @pytest.fixture
 def mock_manifest_cls(monkeypatch):
@@ -226,3 +225,22 @@ def project_data():
         aliases=["alias1", "alias2"]
     )
 
+
+@pytest.mark.parametrize(
+    ["rule_items"],
+    [
+        [["regex_mmp", "regex_dev_mmp", "regex_beta_mmp"]],
+        [[{
+            "type": "custom_regex",
+            "config": {"pattern": r"^\d+\.\d+\.\d+$"}
+        }]],
+        [[
+            "not_empty", 
+            "regex_dev_mm",
+            {"type": "custom_regex", "config": {"pattern": r"^\d+\.\d+$"}}
+        ]],
+    ]
+)
+def test_create_single_version_rules(rule_items):
+    result = factory.create_single_version_rules(rule_items)
+    assert len(result) == len(rule_items)


### PR DESCRIPTION
## Description
Adds a `ConfigurableSingleVersionRule` class that can be used to provide custom configuration to rules that accept it.

## Related Issue
NA

## Type of Change
- [ ] Bug fix
- [X] New feature
- [X] Documentation update
- [ ] Refactoring
- [ ] Other (describe)

## Testing
- [X] Tests pass locally
- [X] Added/updated tests for changes
- [ ] Manual testing performed

## Documentation
- [X] Updated relevant documentation
- [ ] Added docstrings as needed
- [X] Tests demonstrate expected functionality
