### PR TITLE
Support running vertagus without a configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
   Passed alongside `--config`, these options override the corresponding settings in that file. Passed without it, they are the whole configuration and no config file is discovered in the current directory. Settings that describe more than one configuration at once — stages, and a bumper's own options — remain file-only, so `--stage-name` still requires a file.
 * **`--print-config`** prints the configuration a command would run with and exits, which turns a working ad hoc command into a config file: `vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml`.
 * `create-tag` and `create-aliases` now discover `vertagus.yaml`/`.yml`/`.toml` in the current directory like the other commands, instead of defaulting to a `vertagus.toml` path that may not exist.
+* `vertagus validate` now warns when the configuration holds no rules at all, rather than reporting a pass for a validation that checked nothing.
 
 **Fixes.**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ CHANGELOG
 0.5.0
 ---
 
+**New.**
+
+* **Vertagus can now run without a configuration file.** Every setting a config file can hold has a corresponding CLI option, so a command can be configured entirely on the command line:
+
+  ```bash
+  vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
+  ```
+
+  `--manifest` takes a path (whose manifest type is inferred from the file name) or a `path=...,type=...,loc=...,name=...` spec, and `--rule` takes a rule name optionally followed by `:` and a JSON object of rule config. The remaining settings map to `--alias`, `--bumper`, `--root`, `--scm-type`, `--tag-prefix`, `--version-strategy`, `--target-branch` and `--scm-manifest`. Supported by `validate`, `bump`, `create-tag`, `create-aliases`, `show-version` and `show-alias`.
+
+  Passed alongside `--config`, these options override the corresponding settings in that file. Passed without it, they are the whole configuration and no config file is discovered in the current directory. `--stage-name` still requires a config file, since stages are only definable there.
+* **`--print-config`** prints the configuration a command would run with and exits, which turns a working ad hoc command into a config file: `vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml`.
+* `create-tag` and `create-aliases` now discover `vertagus.yaml`/`.yml`/`.toml` in the current directory like the other commands, instead of defaulting to a `vertagus.toml` path that may not exist.
+
 **Breaking changes.**
 
 * **Rules are now configured as a flat list.** The `rules` block is no longer split into `current`, `increment`, and `manifest_comparisons` sub-keys. List every rule directly under `rules`; vertagus infers from the rule class whether it validates a single version or compares versions. A 0.4.x-style mapping is detected and raises an error explaining the migration.

--- a/README.md
+++ b/README.md
@@ -223,8 +223,8 @@ vertagus list-scms
 
 ### Using vertagus without a config file
 
-Everything you can declare in a config file can also be passed as CLI options, so vertagus runs
-in a project that has no `vertagus.yaml`:
+The settings that make up a single project configuration can each be passed as a CLI option, so
+vertagus runs in a project that has no `vertagus.yaml`:
 
 ```
 vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
@@ -256,8 +256,11 @@ vertagus validate -m pyproject.toml --rule any_increment --version-strategy bran
 These options work with `validate`, `bump`, `create-tag`, `create-aliases`, `show-version` and
 `show-alias`. Passed alongside `--config`, they override the corresponding settings in that file,
 which is handy in CI when one job needs a single setting changed. Passed without `--config`, they
-are the whole configuration, and no config file is read from the current directory. Since stages
-are only definable in a config file, `--stage-name` requires one.
+are the whole configuration, and no config file is read from the current directory.
+
+A few settings stay file-only, because they describe more than one configuration at once or
+belong to a specific provider: stages (so `--stage-name` requires a file), a bumper's own options
+beyond its type, and the git SCM's `root` and `remote_name`.
 
 Finally, `--print-config` prints the configuration a command would run with and exits, so you can
 turn a working command into a config file:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features
 - Semver version bump automation (semantic commit messge conventions or user configured)
 - Multiple development stage configurations (e.g., dev, staging, prod)
 - Git tag automation (create version tags, maintain alias tags like 'stable', 'latest')
+- Runs from a config file, or entirely from CLI options with no config file at all
 
 
 Installation
@@ -66,7 +67,9 @@ Vertagus lets you declare some things about how you'd like to maintain your vers
   read commit messages since the most recent version to determine the semver bump level, or `semver` in which you pass
   the bump level as a CLI arg.
 
-You declare these in either a `vertagus.toml` or `vertagus.yaml` file next to your package in your repository. 
+You declare these in either a `vertagus.toml` or `vertagus.yaml` file next to your package in your repository,
+or you pass them as CLI options and skip the file entirely. (See
+[Using vertagus without a config file](#using-vertagus-without-a-config-file) below.)
 Here's an example of the yaml format:
 
 ```yaml
@@ -217,6 +220,53 @@ vertagus list-manifests
 ```
 vertagus list-scms
 ````
+
+### Using vertagus without a config file
+
+Everything you can declare in a config file can also be passed as CLI options, so vertagus runs
+in a project that has no `vertagus.yaml`:
+
+```
+vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
+```
+
+`--manifest` takes either a bare path, whose manifest type is inferred from the file name, or a
+comma-separated list of `key=value` pairs using the keys `path`, `type`, `loc` and `name`:
+
+```
+vertagus validate --manifest 'path=package.json,type=json,loc=version' --rule regex_mmp
+```
+
+`--rule` takes either a bare rule name or a rule name followed by a colon and a JSON object of
+rule configuration:
+
+```
+vertagus validate -m pyproject.toml --rule 'custom_regex:{"pattern": "^1\\..+"}'
+```
+
+The rest of the configuration has an option apiece: `--alias`, `--bumper`, `--root`, `--scm-type`,
+`--tag-prefix`, `--version-strategy`, `--target-branch` and `--scm-manifest`. Under the `branch`
+version strategy, the SCM reads the same file as your first `--manifest` unless you point it
+elsewhere with `--scm-manifest`:
+
+```
+vertagus validate -m pyproject.toml --rule any_increment --version-strategy branch --target-branch main
+```
+
+These options work with `validate`, `bump`, `create-tag`, `create-aliases`, `show-version` and
+`show-alias`. Passed alongside `--config`, they override the corresponding settings in that file,
+which is handy in CI when one job needs a single setting changed. Passed without `--config`, they
+are the whole configuration, and no config file is read from the current directory. Since stages
+are only definable in a config file, `--stage-name` requires one.
+
+Finally, `--print-config` prints the configuration a command would run with and exits, so you can
+turn a working command into a config file:
+
+```
+vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml
+```
+
+For the full details, see the [CLI reference](https://github.com/jdraines/vertagus/blob/main/docs/cli-reference.md#configuration-free-usage).
 
 ### Continuous Integration
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -9,6 +9,10 @@ These options are available for most commands:
 - `--config, -c PATH` - Path to configuration file (default: search for vertagus.yaml/yml/toml in current directory)
 - `--help` - Show help message and exit
 
+The commands that read a configuration file (`validate`, `bump`, `create-tag`, `create-aliases`,
+`show-version`, `show-alias`) also accept the [configuration options](#configuration-free-usage)
+below, which let you run Vertagus without a configuration file at all.
+
 ## Commands
 
 ### `vertagus validate`
@@ -23,6 +27,7 @@ vertagus validate [OPTIONS]
 - `--config, -c PATH` - Path to the configuration file
 - `--stage-name, -s STAGE` - Name of a stage to validate against
 - `--scm-branch, -b BRANCH` - Optional SCM branch to validate against (defaults to configured branch)
+- Any of the [configuration options](#configuration-free-usage), e.g. `--manifest` and `--rule`
 
 **Examples:**
 ```bash
@@ -55,6 +60,7 @@ vertagus bump [OPTIONS] [BUMPER_ARGS...]
 - `--config, -c PATH` - Path to the configuration file
 - `--stage-name, -s STAGE` - Name of a stage for stage-specific bumping
 - `--no-write, -n` - If set, the version will not be written to manifest files (dry run)
+- Any of the [configuration options](#configuration-free-usage), e.g. `--manifest` and `--bumper`
 
 **Bumper Arguments:**
 Arguments passed to the bumper can be in the format `key=value` or as a single positional argument for backward compatibility:
@@ -90,9 +96,10 @@ vertagus create-tag [OPTIONS]
 ```
 
 **Options:**
-- `--config, -c PATH` - Path to the configuration file (default: vertagus.toml in current directory)
+- `--config, -c PATH` - Path to the configuration file
 - `--stage-name, -s STAGE` - Name of a stage for stage-specific tagging
 - `--ref, -r REF` - An SCM ref that should be tagged (default: current commit)
+- Any of the [configuration options](#configuration-free-usage), e.g. `--manifest` and `--tag-prefix`
 
 **Examples:**
 ```bash
@@ -118,9 +125,10 @@ vertagus create-aliases [OPTIONS]
 ```
 
 **Options:**
-- `--config, -c PATH` - Path to the configuration file (default: vertagus.toml in current directory)
+- `--config, -c PATH` - Path to the configuration file
 - `--stage-name, -s STAGE` - Name of a stage for stage-specific aliases
 - `--ref, -r REF` - An SCM ref that should be tagged (default: current commit)
+- Any of the [configuration options](#configuration-free-usage), e.g. `--manifest` and `--alias`
 
 **Examples:**
 ```bash
@@ -213,6 +221,126 @@ vertagus list-scms
 ```
 
 Shows available SCM providers (currently only `git` is supported).
+
+## Configuration-Free Usage
+
+Every setting that a configuration file can hold can also be given directly on the command line,
+so you can run Vertagus in a project that has no `vertagus.yaml`:
+
+```bash
+vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
+```
+
+This is handy for one-off checks, for CI jobs that only need a single rule, and for trying
+Vertagus out before committing to a configuration file.
+
+**Options:**
+
+| Option | Description |
+| --- | --- |
+| `--manifest, -m SPEC` | A manifest that declares the version. Repeatable. |
+| `--rule SPEC` | A validation rule. Repeatable. |
+| `--alias ALIAS` | An alias to apply to the version. Repeatable. |
+| `--bumper TYPE` | The version bumper to use, e.g. `semver`. |
+| `--root PATH` | The project root that relative manifest paths resolve against. |
+| `--scm-type TYPE` | The SCM type. Defaults to `git`. |
+| `--tag-prefix PREFIX` | A prefix for version tags, e.g. `v`. |
+| `--version-strategy {tag,branch}` | How the previous version is found. Defaults to `tag`. |
+| `--target-branch BRANCH` | The branch to read the previous version from. |
+| `--scm-manifest SPEC` | The manifest the SCM reads under the `branch` strategy. |
+| `--print-config` | Print the resolved configuration as YAML and exit. |
+
+### Manifest specs
+
+`--manifest` and `--scm-manifest` accept either a bare path or a comma-separated list of
+`key=value` pairs, with the keys `path`, `type`, `loc` and `name`:
+
+```bash
+# Bare path; the type is inferred from the file name
+vertagus validate --manifest pyproject.toml
+
+# Explicit type and version location
+vertagus validate --manifest 'path=package.json,type=json,loc=version'
+
+# Several manifests, one of them named
+vertagus validate \
+  --manifest pyproject.toml \
+  --manifest 'path=docs/version.yaml,loc=project.version,name=docs' \
+  --rule manifests_comparison
+```
+
+The manifest type is inferred from the file name when `type` is omitted: `pyproject.toml` is a
+`setuptools_pyproject` manifest, and the `.toml`, `.yaml`, `.yml` and `.json` extensions map to the
+manifest types of the same name. Any other file name needs an explicit `type`. Run
+`vertagus list-manifests` to see the available types.
+
+Manifest paths given on the command line are resolved against `--root`, or against the current
+directory when `--root` is not given. The one exception is `--scm-manifest`, whose path is read out
+of source control and so is always relative to the repository root.
+
+### Rule specs
+
+`--rule` accepts either a bare rule name or a rule name and a JSON object holding its
+configuration, separated by a colon:
+
+```bash
+# Bare rule names
+vertagus validate -m pyproject.toml --rule not_empty --rule regex_mmp
+
+# A configured rule
+vertagus validate -m pyproject.toml --rule 'custom_regex:{"pattern": "^1\\..+"}'
+```
+
+Run `vertagus list-rules` to see the available rules.
+
+### Version strategies
+
+The default version strategy is `tag`, which needs no further configuration. Under the `branch`
+strategy, Vertagus reads the previous version from a manifest on the target branch:
+
+```bash
+vertagus validate \
+  --manifest pyproject.toml \
+  --rule any_increment \
+  --version-strategy branch \
+  --target-branch main
+```
+
+When you do not pass `--scm-manifest`, the `branch` strategy reads the same file as your first
+`--manifest`, which is the usual arrangement. Pass `--scm-manifest` when the version lives in a
+different file on the target branch.
+
+### Combining options with a configuration file
+
+The three ways of configuring a command are:
+
+1. **No configuration options** - Vertagus discovers and reads a configuration file, exactly as it
+   always has.
+2. **Configuration options with no `--config`** - the options are the whole configuration. No
+   configuration file is discovered in the current directory, so an ad hoc run cannot silently pick
+   up settings you did not ask for.
+3. **Configuration options together with `--config`** - the options override their counterparts in
+   the file. This is the convenient form for CI, where a job needs one setting changed:
+
+   ```bash
+   # Validate the committed configuration, but against a release branch's tag prefix
+   vertagus validate --config vertagus.yaml --tag-prefix release-
+   ```
+
+   Repeatable options replace the file's list outright rather than adding to it: passing a single
+   `--rule` means that rule and no other.
+
+Because stages can only be defined in a configuration file, `--stage-name` requires one. Configure a
+stage's rules directly with `--rule` instead when you are running without a file.
+
+### Inspecting the resolved configuration
+
+`--print-config` prints the configuration a command would run with and exits, which is both a
+debugging aid and an easy way to grow an ad hoc invocation into a real configuration file:
+
+```bash
+vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml
+```
 
 ## Configuration File Discovery
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -224,8 +224,8 @@ Shows available SCM providers (currently only `git` is supported).
 
 ## Configuration-Free Usage
 
-Every setting that a configuration file can hold can also be given directly on the command line,
-so you can run Vertagus in a project that has no `vertagus.yaml`:
+The settings that make up a single project configuration can each be given directly on the command
+line, so you can run Vertagus in a project that has no `vertagus.yaml`:
 
 ```bash
 vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
@@ -252,8 +252,9 @@ Vertagus out before committing to a configuration file.
 
 ### Manifest specs
 
-`--manifest` and `--scm-manifest` accept either a bare path or a comma-separated list of
-`key=value` pairs, with the keys `path`, `type`, `loc` and `name`:
+`--manifest` accepts either a bare path or a comma-separated list of `key=value` pairs, with the
+keys `path`, `type`, `loc` and `name`. `--scm-manifest` takes the same form minus `name`, which an
+SCM manifest has no use for:
 
 ```bash
 # Bare path; the type is inferred from the file name
@@ -276,7 +277,8 @@ manifest types of the same name. Any other file name needs an explicit `type`. R
 
 Manifest paths given on the command line are resolved against `--root`, or against the current
 directory when `--root` is not given. The one exception is `--scm-manifest`, whose path is read out
-of source control and so is always relative to the repository root.
+of source control and so is always relative to the repository root. A value that contains an `=`
+has to be written as an explicit `path=...` so that it is not mistaken for a misspelled key.
 
 ### Rule specs
 
@@ -307,8 +309,13 @@ vertagus validate \
 ```
 
 When you do not pass `--scm-manifest`, the `branch` strategy reads the same file as your first
-`--manifest`, which is the usual arrangement. Pass `--scm-manifest` when the version lives in a
-different file on the target branch.
+`--manifest`, which is the usual arrangement — including alongside `--config`, when `--manifest` is
+what named the manifest and the file itself sets no SCM manifest of its own. Pass `--scm-manifest`
+when the version lives in a different file on the target branch.
+
+The derived path is expressed relative to the repository, not to `--root`, since that is how source
+control addresses a file. Under `--root pkg`, a `--manifest pyproject.toml` gives the SCM
+`pkg/pyproject.toml`.
 
 ### Combining options with a configuration file
 
@@ -328,10 +335,13 @@ The three ways of configuring a command are:
    ```
 
    Repeatable options replace the file's list outright rather than adding to it: passing a single
-   `--rule` means that rule and no other.
+   `--rule` means that rule and no other — for the project. A stage named with `--stage-name` still
+   contributes its own rules from the file on top of that.
 
-Because stages can only be defined in a configuration file, `--stage-name` requires one. Configure a
-stage's rules directly with `--rule` instead when you are running without a file.
+A few settings stay file-only, because they describe more than one configuration at once or belong
+to a specific provider: stages, a bumper's own options beyond its type, and the git SCM's `root` and
+`remote_name`. Because stages are among them, `--stage-name` requires a configuration file;
+configure a stage's rules directly with `--rule` instead when you are running without one.
 
 ### Inspecting the resolved configuration
 
@@ -341,6 +351,10 @@ debugging aid and an easy way to grow an ad hoc invocation into a real configura
 ```bash
 vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml
 ```
+
+Manifest paths come back out relative to the project root, and a root that is just the directory
+the file would sit in is left out, so the result is a configuration file that still works on another
+machine. A manifest outside the root stays absolute, since a trail of `..` would be no clearer.
 
 ## Configuration File Discovery
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,6 +5,11 @@ Vertagus uses TOML or YAML for its configuration format. The configuration file 
 !!! tip "Configuration Format"
     While both YAML and TOML are supported, we recommend using YAML for better readability and easier maintenance.
 
+!!! note "No configuration file?"
+    Every setting on this page can also be passed directly to a command as an option, with no
+    configuration file at all. See
+    [Configuration-Free Usage](cli-reference.md#configuration-free-usage).
+
 ## Configuration Structure
 
 ### SCM Section

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,8 +81,9 @@ project:
 
 ### Try it without a configuration file
 
-You don't need a configuration file to get started. Every setting can be passed on the command
-line instead, which is useful for a quick look before you commit to a configuration:
+You don't need a configuration file to get started. The settings that describe a single project
+can all be passed on the command line instead, which is useful for a quick look before you commit
+to a configuration:
 
 ```bash
 vertagus validate --manifest pyproject.toml --rule not_empty --rule any_increment

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,18 @@ project:
 
 ## Basic Usage
 
+### Try it without a configuration file
+
+You don't need a configuration file to get started. Every setting can be passed on the command
+line instead, which is useful for a quick look before you commit to a configuration:
+
+```bash
+vertagus validate --manifest pyproject.toml --rule not_empty --rule any_increment
+```
+
+Add `--print-config` to any command to see the configuration it would run with — redirect it to
+`vertagus.yaml` to turn a working command into a working configuration file. See
+[Configuration-Free Usage](cli-reference.md#configuration-free-usage) for the full set of options.
 
 ### Validate version
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ Vertagus is a tool to enable automation around maintaining versions for your sou
 - **Automated version bumping** - Based on semantic commit messages or user configuration
 - **Multi-stage development** - Support for different development stages (dev, staging, prod)
 - **Git tag automation** - Create version tags and maintain alias tags like 'stable', 'latest'
-- **Flexible configuration** - Support for TOML and YAML configuration formats
+- **Flexible configuration** - Support for TOML and YAML configuration formats, or no configuration file at all
 - **Multiple manifest types** - Works with various project manifest files
 
 ## Quick Start
@@ -37,6 +37,12 @@ pip install vertagus
    ```bash
    vertagus bump
    ```
+
+Or skip the configuration file entirely and pass your settings as options:
+
+```bash
+vertagus validate --manifest pyproject.toml --rule not_empty --rule any_increment
+```
 
 ## Documentation Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vertagus"
-version = "0.5.0.dev1"
+version = "0.5.0.dev2"
 description = "A tool to assist the maintenance of package versioning via manifests and source control."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vertagus"
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
 description = "A tool to assist the maintenance of package versioning via manifests and source control."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vertagus/cli/commands/bump.py
+++ b/src/vertagus/cli/commands/bump.py
@@ -8,6 +8,7 @@ from vertagus import operations as ops
 from vertagus.core.project import NoBumperDefinedError
 from vertagus.core.bumper_base import BumperException
 from vertagus.cli import utils as cli_utils
+from vertagus.cli.options import configless_options
 
 
 @click.command(
@@ -27,8 +28,9 @@ from vertagus.cli import utils as cli_utils
     default=False,
     help="If set, the version will not be written to the manifest files.",
 )
-def bump_cmd(context, config, stage_name, no_write):
-    master_config = cli_utils.load_config(config)
+@configless_options
+def bump_cmd(context, config, stage_name, no_write, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, stage_name=stage_name)
     project = factory.create_project(cfgtypes.ProjectData.from_project_config(master_config["project"]))
     bumper_kwargs = _parse_context_args_to_kwargs(context.args)
     scm = factory.create_scm(cfgtypes.ScmData(**master_config["scm"]))

--- a/src/vertagus/cli/commands/create_aliases.py
+++ b/src/vertagus/cli/commands/create_aliases.py
@@ -1,24 +1,20 @@
-import os
-from pathlib import Path
-
 import click
 
-from vertagus.configuration import load
 from vertagus.configuration import types as cfgtypes
 from vertagus import factory
 from vertagus import operations as ops
+from vertagus.cli import utils as cli_utils
+from vertagus.cli.options import configless_options
 
 
 @click.command(name="create-aliases")
-@click.option("--config", "-c", default=str(Path(os.getcwd()) / "vertagus.toml"), help="Path to the configuration file")
+@click.option("--config", "-c", default=None, help="Path to the configuration file")
 @click.option("--stage-name", "-s", default=None, help="Name of a stage")
 @click.option("--ref", "-r", default=None, help="An SCM ref that should be tagged. Default is current commit.")
-def create_aliases_cmd(config, stage_name, ref):
-    master_config = load.load_config(config)
+@configless_options
+def create_aliases_cmd(config, stage_name, ref, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, stage_name=stage_name)
     scm = factory.create_scm(data=cfgtypes.ScmData(**master_config["scm"]))
-    default_package_root = Path(config).parent
-    if "root" not in master_config["project"]:
-        master_config["project"]["root"] = default_package_root
     project = factory.create_project(
         cfgtypes.ProjectData.from_project_config(master_config["project"]),
     )

--- a/src/vertagus/cli/commands/create_tag.py
+++ b/src/vertagus/cli/commands/create_tag.py
@@ -1,20 +1,19 @@
-import os
-from pathlib import Path
-
 import click
 
 from vertagus.configuration import types as cfgtypes
 from vertagus import factory
 from vertagus import operations as ops
 from vertagus.cli import utils as cli_utils
+from vertagus.cli.options import configless_options
 
 
 @click.command(name="create-tag")
-@click.option("--config", "-c", default=str(Path(os.getcwd()) / "vertagus.toml"), help="Path to the configuration file")
+@click.option("--config", "-c", default=None, help="Path to the configuration file")
 @click.option("--stage-name", "-s", default=None, help="Name of a stage")
 @click.option("--ref", "-r", default=None, help="An SCM ref that should be tagged. Default is current commit.")
-def create_tag_cmd(config, stage_name, ref):
-    master_config = cli_utils.load_config(config)
+@configless_options
+def create_tag_cmd(config, stage_name, ref, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, stage_name=stage_name)
     scm = factory.create_scm(data=cfgtypes.ScmData(**master_config["scm"]))
     project = factory.create_project(
         cfgtypes.ProjectData.from_project_config(master_config["project"]),

--- a/src/vertagus/cli/commands/show_alias.py
+++ b/src/vertagus/cli/commands/show_alias.py
@@ -6,13 +6,15 @@ from vertagus.configuration import types as cfgtypes
 from vertagus import factory
 from vertagus.cli import utils as cli_utils
 from vertagus.aliases import loader as alias_loader
+from vertagus.cli.options import configless_options
 
 
 @click.command("show-alias")
 @click.argument("alias_name", required=True)
 @click.option("--config", "-c", default=None, help="Path to the configuration file")
-def show_alias_cmd(alias_name, config):
-    master_config = cli_utils.load_config(config, suppress_logging=True)
+@configless_options
+def show_alias_cmd(alias_name, config, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, suppress_logging=True)
     project = factory.create_project(cfgtypes.ProjectData.from_project_config(master_config["project"]))
     version = project.get_version()
     if not version:

--- a/src/vertagus/cli/commands/show_version.py
+++ b/src/vertagus/cli/commands/show_version.py
@@ -5,12 +5,14 @@ import click
 from vertagus.configuration import types as cfgtypes
 from vertagus import factory
 from vertagus.cli import utils as cli_utils
+from vertagus.cli.options import configless_options
 
 
 @click.command("show-version")
 @click.option("--config", "-c", default=None, help="Path to the configuration file")
-def show_version_cmd(config):
-    master_config = cli_utils.load_config(config, suppress_logging=True)
+@configless_options
+def show_version_cmd(config, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, suppress_logging=True)
     project = factory.create_project(cfgtypes.ProjectData.from_project_config(master_config["project"]))
     version = project.get_version()
     if not version:

--- a/src/vertagus/cli/commands/validate.py
+++ b/src/vertagus/cli/commands/validate.py
@@ -6,6 +6,7 @@ from vertagus.configuration import types as cfgtypes
 from vertagus import factory
 from vertagus import operations as ops
 from vertagus.cli import utils as cli_utils
+from vertagus.cli.options import configless_options
 
 
 @click.command("validate")
@@ -14,8 +15,9 @@ from vertagus.cli import utils as cli_utils
 @click.option(
     "--scm-branch", "-b", default=None, help="Optional SCM branch to validate against. Defaults to configured branch."
 )
-def validate_cmd(config, stage_name, scm_branch):
-    master_config = cli_utils.load_config(config)
+@configless_options
+def validate_cmd(config, stage_name, scm_branch, **cli_opts):
+    master_config = cli_utils.resolve_config(config, cli_opts, stage_name=stage_name)
     scm = factory.create_scm(cfgtypes.ScmData(**master_config["scm"]))
     project = factory.create_project(cfgtypes.ProjectData.from_project_config(master_config["project"]))
     if not ops.validate_project_version(scm=scm, project=project, stage_name=stage_name, scm_branch=scm_branch):

--- a/src/vertagus/cli/options.py
+++ b/src/vertagus/cli/options.py
@@ -1,0 +1,52 @@
+"""Shared click options that let a command be configured without a configuration file."""
+
+import click
+
+_MANIFEST_HELP = (
+    "A manifest that declares the version, as a path or as comma-separated key=value "
+    "pairs: path=<path>[,type=<type>][,loc=<dotted.path>][,name=<name>]. Repeatable."
+)
+
+_RULE_HELP = (
+    'A validation rule, either a rule name or \'name:{"key": "value"}\' to configure it. Repeatable. '
+    "Run `vertagus list-rules` to see the available rules."
+)
+
+_SCM_MANIFEST_HELP = (
+    "The manifest the SCM reads to find the previous version under the 'branch' version "
+    "strategy, in the same format as --manifest. Defaults to the first --manifest."
+)
+
+
+def configless_options(f):
+    """Add the options that build a configuration in place of a configuration file.
+
+    Commands decorated with this receive the option values as extra keyword arguments,
+    which they hand to :func:`vertagus.cli.utils.resolve_config` unchanged.
+    """
+    options = [
+        click.option("--manifest", "-m", multiple=True, help=_MANIFEST_HELP),
+        click.option("--rule", multiple=True, help=_RULE_HELP),
+        click.option("--alias", multiple=True, help="An alias to apply to the version. Repeatable."),
+        click.option("--bumper", default=None, help="The type of version bumper to use."),
+        click.option("--root", default=None, help="The project root that relative manifest paths resolve against."),
+        click.option("--scm-type", default=None, help="The SCM type. Defaults to 'git'."),
+        click.option("--tag-prefix", default=None, help="A prefix for version tags, e.g. 'v'."),
+        click.option(
+            "--version-strategy",
+            type=click.Choice(["tag", "branch"], case_sensitive=False),
+            default=None,
+            help="How the previous version is found: from SCM tags, or from a manifest on a branch.",
+        ),
+        click.option("--target-branch", default=None, help="The branch to read the previous version from."),
+        click.option("--scm-manifest", default=None, help=_SCM_MANIFEST_HELP),
+        click.option(
+            "--print-config",
+            is_flag=True,
+            default=False,
+            help="Print the resolved configuration as YAML and exit without running the command.",
+        ),
+    ]
+    for option in reversed(options):
+        f = option(f)
+    return f

--- a/src/vertagus/cli/utils.py
+++ b/src/vertagus/cli/utils.py
@@ -2,8 +2,13 @@ import click
 import sys
 import os
 from pathlib import Path
+
+import yaml
+
+from vertagus.configuration import from_cli
 from vertagus.configuration import load
 from vertagus.configuration import types as cfgtypes
+from vertagus.errors import ConfigurationError
 
 
 def get_cwd() -> Path:
@@ -38,3 +43,45 @@ def load_config(config_path: str | None, suppress_logging=False) -> cfgtypes.Mas
     if "root" not in master_config["project"]:
         master_config["project"]["root"] = default_package_root
     return master_config
+
+
+def resolve_config(
+    config_path: str | None,
+    cli_opts: dict | None = None,
+    stage_name: str | None = None,
+    suppress_logging: bool = False,
+) -> cfgtypes.MasterConfig:
+    """Resolve the configuration a command should run with.
+
+    With no configuration options on the command line, this behaves exactly like
+    :func:`load_config`. Otherwise the options either overlay a configuration file, when
+    one was named with ``--config``, or stand in for it entirely. In the latter case no
+    configuration file is discovered in the current directory, so that an ad hoc
+    invocation cannot silently pick up settings the user did not ask for.
+    """
+    cli_opts = dict(cli_opts or {})
+    print_config = cli_opts.pop("print_config", False)
+    opts = from_cli.CliConfigOptions(**cli_opts)
+
+    if not opts.any_provided():
+        master_config = load_config(config_path, suppress_logging or print_config)
+    elif config_path:
+        master_config = from_cli.merge_config(load_config(config_path, suppress_logging or print_config), opts)
+    else:
+        if stage_name:
+            raise ConfigurationError(
+                f"Cannot use --stage-name {stage_name!r} without a configuration file: stages are "
+                "defined in a vertagus configuration file. Pass --config, or configure the stage's "
+                "rules directly with --rule."
+            )
+        master_config = from_cli.build_master_config(opts)
+
+    if print_config:
+        echo_config_and_exit(master_config)
+    return master_config
+
+
+def echo_config_and_exit(master_config: cfgtypes.MasterConfig) -> None:
+    """Print a resolved configuration as YAML and exit successfully."""
+    click.echo(yaml.dump(dict(master_config), default_flow_style=False, sort_keys=False))
+    sys.exit(0)

--- a/src/vertagus/cli/utils.py
+++ b/src/vertagus/cli/utils.py
@@ -1,4 +1,5 @@
 import click
+import copy
 import sys
 import os
 from pathlib import Path
@@ -83,5 +84,35 @@ def resolve_config(
 
 def echo_config_and_exit(master_config: cfgtypes.MasterConfig) -> None:
     """Print a resolved configuration as YAML and exit successfully."""
-    click.echo(yaml.dump(dict(master_config), default_flow_style=False, sort_keys=False))
+    click.echo(yaml.dump(_portable_config(master_config), default_flow_style=False, sort_keys=False))
     sys.exit(0)
+
+
+def _portable_config(master_config: cfgtypes.MasterConfig) -> dict:
+    """Rewrite a resolved configuration so that it is worth saving as a file.
+
+    Options resolve manifest paths against the project root to reach the right file from
+    wherever the command ran. Printed back out verbatim, those absolute paths would make
+    a configuration file that only works on the machine that produced it, so they are
+    turned back into the root-relative paths a hand-written file would have used. A root
+    that is merely the directory the file will sit in is dropped, since that is what
+    vertagus assumes anyway.
+    """
+    config = copy.deepcopy(dict(master_config))
+    project = config.get("project") or {}
+    root = project.get("root")
+    if not root or not os.path.isabs(root):
+        return config
+
+    for manifest in project.get("manifests") or []:
+        path = manifest.get("path")
+        if not path or not os.path.isabs(path):
+            continue
+        relative = os.path.relpath(path, root)
+        # A manifest outside the root is clearer left absolute than as a trail of '..'.
+        if not relative.startswith(os.pardir):
+            manifest["path"] = relative
+
+    if os.path.abspath(root) == os.path.abspath(os.getcwd()):
+        project.pop("root", None)
+    return config

--- a/src/vertagus/configuration/from_cli.py
+++ b/src/vertagus/configuration/from_cli.py
@@ -1,0 +1,263 @@
+"""Build a vertagus configuration from CLI options, without a configuration file.
+
+The CLI can assemble the same :class:`~vertagus.configuration.types.MasterConfig`
+mapping that :mod:`vertagus.configuration.load` reads from disk, so that commands
+work identically whether their settings came from ``vertagus.yaml`` or from flags
+like ``--manifest`` and ``--rule``.
+"""
+
+import copy
+import json
+import os
+import typing as T
+from dataclasses import dataclass
+
+from vertagus.errors import ConfigurationError
+
+from .types import ManifestConfig, MasterConfig
+
+DEFAULT_SCM_TYPE = "git"
+
+_MANIFEST_TYPE_BY_FILENAME = {
+    "pyproject.toml": "setuptools_pyproject",
+}
+
+_MANIFEST_TYPE_BY_EXTENSION = {
+    ".toml": "toml",
+    ".yaml": "yaml",
+    ".yml": "yaml",
+    ".json": "json",
+}
+
+_MANIFEST_SPEC_KEYS = ("path", "type", "loc", "name")
+
+
+@dataclass
+class CliConfigOptions:
+    """The configuration-defining options accepted by the vertagus commands."""
+
+    manifest: tuple[str, ...] = ()
+    rule: tuple[str, ...] = ()
+    alias: tuple[str, ...] = ()
+    bumper: str | None = None
+    root: str | None = None
+    scm_type: str | None = None
+    tag_prefix: str | None = None
+    version_strategy: str | None = None
+    target_branch: str | None = None
+    scm_manifest: str | None = None
+
+    def any_provided(self) -> bool:
+        """Whether the user supplied any configuration on the command line."""
+        return any(
+            [
+                self.manifest,
+                self.rule,
+                self.alias,
+                self.bumper,
+                self.root,
+                self.scm_type,
+                self.tag_prefix,
+                self.version_strategy,
+                self.target_branch,
+                self.scm_manifest,
+            ]
+        )
+
+
+def infer_manifest_type(path: str) -> str:
+    """Guess a manifest type from a file name, e.g. ``pyproject.toml`` -> ``setuptools_pyproject``."""
+    basename = os.path.basename(path).lower()
+    if basename in _MANIFEST_TYPE_BY_FILENAME:
+        return _MANIFEST_TYPE_BY_FILENAME[basename]
+    extension = os.path.splitext(basename)[1]
+    if extension in _MANIFEST_TYPE_BY_EXTENSION:
+        return _MANIFEST_TYPE_BY_EXTENSION[extension]
+    raise ConfigurationError(
+        f"Could not determine the manifest type of {path!r}. Pass it explicitly, e.g. "
+        f"--manifest 'path={path},type=yaml'. Run `vertagus list-manifests` to see the available types."
+    )
+
+
+def parse_manifest_spec(spec: str, index: int = 0, base_dir: str | None = None) -> ManifestConfig:
+    """Parse a ``--manifest`` value.
+
+    A spec is either a bare path (``src/pyproject.toml``) or a comma-separated list of
+    ``key=value`` pairs (``path=version.json,type=json,loc=project.version``). Supported
+    keys are ``path``, ``type``, ``loc`` and ``name``. The type is inferred from the file
+    name when it is omitted, and the name defaults to ``manifest_<n>``.
+
+    Relative paths are resolved against ``base_dir`` (the current directory by default) so
+    that a manifest named on the command line always means what the user typed, regardless
+    of where any configuration file lives.
+    """
+    fields = _parse_spec_fields(spec, valid_keys=_MANIFEST_SPEC_KEYS, spec_name="manifest")
+    path = fields.get("path")
+    if not path:
+        raise ConfigurationError(f"Invalid manifest {spec!r}: no path was given.")
+
+    manifest_type = fields.get("type") or infer_manifest_type(path)
+    manifest: ManifestConfig = {
+        "name": fields.get("name") or f"manifest_{index + 1}",
+        "type": manifest_type,
+        "path": os.path.abspath(os.path.join(base_dir or os.getcwd(), path)),
+        "loc": fields.get("loc"),
+    }
+    return manifest
+
+
+def parse_rule_spec(spec: str) -> str | dict:
+    """Parse a ``--rule`` value.
+
+    A rule is either a bare name (``not_empty``) or a name and a JSON object holding its
+    configuration, separated by a colon (``regex:{"pattern": "^\\\\d+"}``).
+    """
+    name, separator, raw_config = spec.partition(":")
+    name = name.strip()
+    if not name:
+        raise ConfigurationError(f"Invalid rule {spec!r}: no rule name was given.")
+    if not separator:
+        return name
+    try:
+        config = json.loads(raw_config)
+    except json.JSONDecodeError as e:
+        raise ConfigurationError(
+            f"Invalid rule {spec!r}: the configuration after ':' is not valid JSON ({e}). "
+            f'Expected something like --rule \'{name}:{{"key": "value"}}\'.'
+        ) from e
+    if not isinstance(config, dict):
+        raise ConfigurationError(
+            f"Invalid rule {spec!r}: the configuration after ':' must be a JSON object, got {type(config).__name__}."
+        )
+    return {"type": name, "config": config}
+
+
+def build_config_overlay(opts: CliConfigOptions) -> dict:
+    """Build a partial :class:`MasterConfig` holding only the settings the user supplied."""
+    overlay: dict[str, dict] = {"scm": {}, "project": {}}
+
+    if opts.scm_type:
+        overlay["scm"]["type"] = opts.scm_type
+    if opts.tag_prefix is not None:
+        overlay["scm"]["tag_prefix"] = opts.tag_prefix
+    if opts.version_strategy:
+        overlay["scm"]["version_strategy"] = opts.version_strategy
+    if opts.target_branch:
+        overlay["scm"]["target_branch"] = opts.target_branch
+    if opts.scm_manifest:
+        overlay["scm"].update(_parse_scm_manifest_spec(opts.scm_manifest))
+
+    if opts.manifest:
+        base_dir = os.path.abspath(opts.root) if opts.root else None
+        overlay["project"]["manifests"] = [
+            parse_manifest_spec(spec, index=i, base_dir=base_dir) for i, spec in enumerate(opts.manifest)
+        ]
+    if opts.rule:
+        overlay["project"]["rules"] = [parse_rule_spec(spec) for spec in opts.rule]
+    if opts.alias:
+        overlay["project"]["aliases"] = list(opts.alias)
+    if opts.bumper:
+        overlay["project"]["bumper"] = {"type": opts.bumper}
+    if opts.root:
+        overlay["project"]["root"] = os.path.abspath(opts.root)
+
+    return overlay
+
+
+def build_master_config(opts: CliConfigOptions) -> MasterConfig:
+    """Build a complete configuration from command line options alone."""
+    overlay = build_config_overlay(opts)
+    config: MasterConfig = {
+        "scm": {"type": DEFAULT_SCM_TYPE, **overlay["scm"]},  # type: ignore[typeddict-item]
+        "project": {"root": os.getcwd(), **overlay["project"]},  # type: ignore[typeddict-item]
+    }
+
+    manifests = config["project"].get("manifests")
+    if not manifests:
+        raise ConfigurationError(
+            "No manifests were configured. Either create a vertagus configuration file "
+            "(`vertagus init`) or name a manifest on the command line, e.g. "
+            "--manifest pyproject.toml."
+        )
+
+    _apply_scm_manifest_default(config, manifests)
+    return config
+
+
+def merge_config(base: MasterConfig, opts: CliConfigOptions) -> MasterConfig:
+    """Overlay command line options onto a configuration loaded from a file.
+
+    Settings named on the command line replace their counterparts in the file. Options
+    that accept multiple values replace the file's list outright rather than adding to it.
+    """
+    overlay = build_config_overlay(opts)
+    merged = copy.deepcopy(base)
+    for section, values in overlay.items():
+        if not values:
+            continue
+        section_config = merged.get(section) or {}
+        section_config.update(values)
+        merged[section] = section_config  # type: ignore[literal-required]
+    return merged
+
+
+def _apply_scm_manifest_default(config: MasterConfig, manifests: list[ManifestConfig]) -> None:
+    """Point a branch-strategy SCM at the first project manifest when it has none of its own.
+
+    The manifest that declares the version is usually the same file on both sides, and
+    naming it twice on the command line is pure ceremony.
+    """
+    scm = config["scm"]
+    if scm.get("version_strategy") != "branch" or scm.get("manifest_path"):
+        return
+    primary = manifests[0]
+    scm["manifest_path"] = os.path.relpath(primary["path"], config["project"].get("root") or os.getcwd())
+    scm["manifest_type"] = primary["type"]
+    if primary.get("loc"):
+        scm["manifest_loc"] = primary["loc"]
+
+
+def _parse_scm_manifest_spec(spec: str) -> dict[str, T.Any]:
+    """Parse ``--scm-manifest`` into the ``manifest_*`` keys of the scm configuration.
+
+    Unlike project manifests, this path is read out of source control rather than off
+    disk, so it stays exactly as the user wrote it: relative to the repository root.
+    """
+    fields = _parse_spec_fields(spec, valid_keys=_MANIFEST_SPEC_KEYS, spec_name="scm manifest")
+    path = fields.get("path")
+    if not path:
+        raise ConfigurationError(f"Invalid scm manifest {spec!r}: no path was given.")
+    scm_config: dict[str, T.Any] = {
+        "manifest_path": path,
+        "manifest_type": fields.get("type") or infer_manifest_type(path),
+    }
+    if fields.get("loc"):
+        scm_config["manifest_loc"] = fields["loc"]
+    return scm_config
+
+
+def _parse_spec_fields(spec: str, valid_keys: tuple[str, ...], spec_name: str) -> dict[str, str]:
+    """Parse a bare path or a comma-separated ``key=value`` spec into a mapping."""
+    spec = spec.strip()
+    if not spec:
+        raise ConfigurationError(f"Invalid {spec_name}: the value is empty.")
+    if "=" not in spec:
+        return {"path": spec}
+
+    fields: dict[str, str] = {}
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        key, separator, value = part.partition("=")
+        key = key.strip()
+        if not separator:
+            raise ConfigurationError(
+                f"Invalid {spec_name} {spec!r}: expected 'key=value' pairs separated by commas, but found {part!r}."
+            )
+        if key not in valid_keys:
+            raise ConfigurationError(
+                f"Invalid {spec_name} {spec!r}: unknown key {key!r}. Valid keys are: {', '.join(valid_keys)}."
+            )
+        fields[key] = value.strip()
+    return fields

--- a/src/vertagus/configuration/from_cli.py
+++ b/src/vertagus/configuration/from_cli.py
@@ -31,6 +31,21 @@ _MANIFEST_TYPE_BY_EXTENSION = {
 
 _MANIFEST_SPEC_KEYS = ("path", "type", "loc", "name")
 
+# An scm manifest is not a project manifest and never carries a name, so accepting one
+# would only let a `name=` silently go nowhere.
+_SCM_MANIFEST_SPEC_KEYS = ("path", "type", "loc")
+
+# Every option below is a single value that means nothing when empty; only --tag-prefix
+# is meaningfully empty, as the way to say "this configuration has no tag prefix".
+_NON_EMPTY_SCALAR_OPTIONS = (
+    ("bumper", "--bumper"),
+    ("root", "--root"),
+    ("scm_type", "--scm-type"),
+    ("version_strategy", "--version-strategy"),
+    ("target_branch", "--target-branch"),
+    ("scm_manifest", "--scm-manifest"),
+)
+
 
 @dataclass
 class CliConfigOptions:
@@ -48,21 +63,22 @@ class CliConfigOptions:
     scm_manifest: str | None = None
 
     def any_provided(self) -> bool:
-        """Whether the user supplied any configuration on the command line."""
-        return any(
-            [
-                self.manifest,
-                self.rule,
-                self.alias,
-                self.bumper,
-                self.root,
-                self.scm_type,
-                self.tag_prefix,
-                self.version_strategy,
-                self.target_branch,
-                self.scm_manifest,
-            ]
+        """Whether the user supplied any configuration on the command line.
+
+        A scalar option counts as supplied whenever it was passed at all, empty string
+        included, so that ``--tag-prefix ''`` — the way to say "no tag prefix" — is not
+        mistaken for an option the user left off.
+        """
+        scalars = (
+            self.bumper,
+            self.root,
+            self.scm_type,
+            self.tag_prefix,
+            self.version_strategy,
+            self.target_branch,
+            self.scm_manifest,
         )
+        return any([self.manifest, self.rule, self.alias]) or any(value is not None for value in scalars)
 
 
 def infer_manifest_type(path: str) -> str:
@@ -134,6 +150,7 @@ def parse_rule_spec(spec: str) -> str | dict:
 
 def build_config_overlay(opts: CliConfigOptions) -> dict:
     """Build a partial :class:`MasterConfig` holding only the settings the user supplied."""
+    _reject_empty_scalars(opts)
     overlay: dict[str, dict] = {"scm": {}, "project": {}}
 
     if opts.scm_type:
@@ -198,6 +215,10 @@ def merge_config(base: MasterConfig, opts: CliConfigOptions) -> MasterConfig:
         section_config = merged.get(section) or {}
         section_config.update(values)
         merged[section] = section_config  # type: ignore[literal-required]
+    if opts.manifest:
+        # The manifests came from the command line, so the branch-strategy default reads
+        # the same way it does without a configuration file.
+        _apply_scm_manifest_default(merged, overlay["project"]["manifests"])
     return merged
 
 
@@ -206,15 +227,36 @@ def _apply_scm_manifest_default(config: MasterConfig, manifests: list[ManifestCo
 
     The manifest that declares the version is usually the same file on both sides, and
     naming it twice on the command line is pure ceremony.
+
+    The SCM reads this path out of source control rather than off disk, so it has to be
+    relative to the repository — which is the SCM's own root, not the project root. The
+    two differ whenever ``--root`` points into a subdirectory of the repository.
     """
     scm = config["scm"]
     if scm.get("version_strategy") != "branch" or scm.get("manifest_path"):
         return
     primary = manifests[0]
-    scm["manifest_path"] = os.path.relpath(primary["path"], config["project"].get("root") or os.getcwd())
+    scm["manifest_path"] = _repo_relative_path(primary["path"], scm.get("root"))
     scm["manifest_type"] = primary["type"]
     if primary.get("loc"):
         scm["manifest_loc"] = primary["loc"]
+
+
+def _repo_relative_path(path: str, scm_root: str | None) -> str:
+    """Express an absolute manifest path the way source control addresses it.
+
+    Paths are resolved against the SCM root, and always with forward slashes, since that
+    is how git names a file in ``git show <ref>:<path>`` on every platform.
+    """
+    relative = os.path.relpath(path, scm_root or os.getcwd())
+    return relative.replace(os.sep, "/")
+
+
+def _reject_empty_scalars(opts: CliConfigOptions) -> None:
+    """Reject single-valued options passed as an empty string, which cannot mean anything."""
+    for attribute, flag in _NON_EMPTY_SCALAR_OPTIONS:
+        if getattr(opts, attribute) == "":
+            raise ConfigurationError(f"Invalid {flag}: the value is empty.")
 
 
 def _parse_scm_manifest_spec(spec: str) -> dict[str, T.Any]:
@@ -223,7 +265,7 @@ def _parse_scm_manifest_spec(spec: str) -> dict[str, T.Any]:
     Unlike project manifests, this path is read out of source control rather than off
     disk, so it stays exactly as the user wrote it: relative to the repository root.
     """
-    fields = _parse_spec_fields(spec, valid_keys=_MANIFEST_SPEC_KEYS, spec_name="scm manifest")
+    fields = _parse_spec_fields(spec, valid_keys=_SCM_MANIFEST_SPEC_KEYS, spec_name="scm manifest")
     path = fields.get("path")
     if not path:
         raise ConfigurationError(f"Invalid scm manifest {spec!r}: no path was given.")
@@ -237,12 +279,24 @@ def _parse_scm_manifest_spec(spec: str) -> dict[str, T.Any]:
 
 
 def _parse_spec_fields(spec: str, valid_keys: tuple[str, ...], spec_name: str) -> dict[str, str]:
-    """Parse a bare path or a comma-separated ``key=value`` spec into a mapping."""
+    """Parse a bare path or a comma-separated ``key=value`` spec into a mapping.
+
+    A value is read as a spec when it opens with one of ``valid_keys``, and as a bare path
+    when it holds no ``=`` at all. Anything else is ambiguous — a misspelled key and a path
+    containing an ``=`` look alike — so it is rejected rather than guessed at. Keys given
+    without a value are dropped, leaving the same defaults as leaving the key off entirely.
+    """
     spec = spec.strip()
     if not spec:
         raise ConfigurationError(f"Invalid {spec_name}: the value is empty.")
     if "=" not in spec:
         return {"path": spec}
+    if spec.split(",", 1)[0].partition("=")[0].strip() not in valid_keys:
+        raise ConfigurationError(
+            f"Invalid {spec_name} {spec!r}: a 'key=value' spec must open with one of "
+            f"{', '.join(valid_keys)}. If this is a path that contains an '=', write it as "
+            f"'path={spec}'."
+        )
 
     fields: dict[str, str] = {}
     for part in spec.split(","):
@@ -259,5 +313,7 @@ def _parse_spec_fields(spec: str, valid_keys: tuple[str, ...], spec_name: str) -
             raise ConfigurationError(
                 f"Invalid {spec_name} {spec!r}: unknown key {key!r}. Valid keys are: {', '.join(valid_keys)}."
             )
-        fields[key] = value.strip()
+        value = value.strip()
+        if value:
+            fields[key] = value
     return fields

--- a/src/vertagus/core/project.py
+++ b/src/vertagus/core/project.py
@@ -60,6 +60,14 @@ class Project(Package):
             aliases.extend(stage.get_version_aliases(version))
         return list(dict.fromkeys(aliases).keys())
 
+    def has_rules(self, stage_name: str | None = None) -> bool:
+        """Whether validating against this stage would run any rule at all."""
+        return bool(
+            self._get_current_version_rules(stage_name)
+            or self._get_version_increment_rules(stage_name)
+            or self._get_manifest_versions_comparison_rules(stage_name)
+        )
+
     def validate_version(self, previous_version: str, stage_name: str | None = None):
         primary_manifest = self._get_manifests(stage_name)[0]
         current_version = self.get_version(stage_name)

--- a/src/vertagus/operations.py
+++ b/src/vertagus/operations.py
@@ -12,6 +12,13 @@ logger = getLogger(__name__)
 def validate_project_version(
     scm: ScmBase, project: Project, stage_name: str | None = None, scm_branch: str | None = None
 ) -> bool:
+    if not project.has_rules(stage_name):
+        logger.warning(
+            "No rules are configured, so this validation passes without checking anything. "
+            "Add rules to the configuration file, or pass them with --rule; "
+            "run `vertagus list-rules` to see what is available."
+        )
+
     # Get the previous version using SCM's strategy-aware method
     previous_version = scm.get_highest_version(branch=scm_branch)
 

--- a/test/cli/commands/test_cli_validate.py
+++ b/test/cli/commands/test_cli_validate.py
@@ -70,3 +70,76 @@ def test_validate_simple(
     load_config_mock.return_value = config
     result = runner.invoke(validate_cmd, ["--config", config_name])
     assert result.exit_code == expected_exit_code
+
+
+@pytest.mark.parametrize(
+    "manifest_name, expected_exit_code",
+    [
+        ("0.2.0.yaml", 0),
+        ("0.1.0.yaml", 1),
+    ],
+)
+def test_validate_without_a_config_file(runner: CliRunner, manifest_name: str, expected_exit_code: int):
+    result = runner.invoke(
+        validate_cmd,
+        [
+            "--manifest",
+            f"path={_mock_manifests_dir / manifest_name},type=yaml,loc=project.version",
+            "--rule",
+            "not_empty",
+            "--rule",
+            "any_increment",
+        ],
+    )
+    assert result.exit_code == expected_exit_code
+
+
+def test_validate_without_a_config_file_ignores_a_config_file_in_the_cwd(runner: CliRunner, load_config_mock):
+    runner.invoke(
+        validate_cmd,
+        ["--manifest", f"path={_mock_manifests_dir / '0.2.0.yaml'},type=yaml,loc=project.version"],
+    )
+    load_config_mock.assert_not_called()
+
+
+def test_validate_cli_options_override_a_config_file(runner: CliRunner, load_config_mock):
+    config = load_config("01-simple.yaml")
+    config["project"]["manifests"] = [
+        {
+            "name": "0.1.0.yaml",
+            "type": "yaml",
+            "path": str(_mock_manifests_dir / "0.1.0.yaml"),
+            "loc": "project.version",
+        }
+    ]
+    load_config_mock.return_value = config
+
+    # The configured manifest is behind the mocked SCM version, so validation only passes
+    # if the manifest named on the command line replaced it.
+    result = runner.invoke(
+        validate_cmd,
+        [
+            "--config",
+            "01-simple.yaml",
+            "--manifest",
+            f"path={_mock_manifests_dir / '0.2.0.yaml'},type=yaml,loc=project.version",
+        ],
+    )
+    assert result.exit_code == 0
+
+
+def test_validate_rejects_a_stage_name_without_a_config_file(runner: CliRunner):
+    result = runner.invoke(
+        validate_cmd,
+        ["--manifest", f"path={_mock_manifests_dir / '0.2.0.yaml'},type=yaml", "--stage-name", "dev"],
+    )
+    assert result.exit_code != 0
+
+
+def test_validate_print_config(runner: CliRunner):
+    result = runner.invoke(
+        validate_cmd,
+        ["--manifest", f"path={_mock_manifests_dir / '0.2.0.yaml'},type=yaml", "--print-config", "--tag-prefix", "v"],
+    )
+    assert result.exit_code == 0
+    assert "tag_prefix: v" in result.output

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import patch, MagicMock
 
 from vertagus.cli import utils as cli_utils
+from vertagus.errors import ConfigurationError
 
 
 @patch("vertagus.cli.utils.os.getcwd")
@@ -47,3 +48,50 @@ def test_load_config(mock_load_config, mock_validate_config_path):
     mock_load_config.return_value = {"project": {}}
     config = cli_utils.load_config(None)
     assert config == {"project": {"root": str(Path("/my/config"))}}
+
+
+@patch("vertagus.cli.utils.load_config")
+def test_resolve_config_without_cli_options_loads_a_file(mock_load_config):
+    mock_load_config.return_value = {"project": {}, "scm": {}}
+
+    config = cli_utils.resolve_config("some/config.yaml", {})
+
+    mock_load_config.assert_called_once_with("some/config.yaml", False)
+    assert config == {"project": {}, "scm": {}}
+
+
+@patch("vertagus.cli.utils.load_config")
+def test_resolve_config_merges_cli_options_onto_a_file(mock_load_config):
+    mock_load_config.return_value = {"project": {"rules": ["not_empty"]}, "scm": {"type": "git"}}
+
+    config = cli_utils.resolve_config("some/config.yaml", {"rule": ("any_increment",), "tag_prefix": "v"})
+
+    assert config["project"]["rules"] == ["any_increment"]
+    assert config["scm"]["tag_prefix"] == "v"
+
+
+@patch("vertagus.cli.utils.load_config")
+def test_resolve_config_from_cli_options_alone_ignores_config_files(mock_load_config, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "vertagus.yaml").write_text("project: {}\n")
+
+    config = cli_utils.resolve_config(None, {"manifest": ("pyproject.toml",), "rule": ("not_empty",)})
+
+    mock_load_config.assert_not_called()
+    assert config["project"]["manifests"][0]["path"] == str(tmp_path / "pyproject.toml")
+    assert config["scm"] == {"type": "git"}
+
+
+def test_resolve_config_rejects_a_stage_name_without_a_config_file():
+    with pytest.raises(ConfigurationError, match="Cannot use --stage-name"):
+        cli_utils.resolve_config(None, {"manifest": ("pyproject.toml",)}, stage_name="dev")
+
+
+def test_resolve_config_print_config_exits(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        cli_utils.resolve_config(None, {"manifest": ("pyproject.toml",), "print_config": True})
+
+    assert excinfo.value.code == 0
+    assert "manifests:" in capsys.readouterr().out

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import pytest
+import yaml
 from unittest.mock import patch, MagicMock
 
 from vertagus.cli import utils as cli_utils
@@ -95,3 +96,45 @@ def test_resolve_config_print_config_exits(capsys, tmp_path, monkeypatch):
 
     assert excinfo.value.code == 0
     assert "manifests:" in capsys.readouterr().out
+
+
+def test_print_config_output_can_be_saved_as_a_config_file(capsys, tmp_path, monkeypatch):
+    """The documented `--print-config > vertagus.yaml` recipe has to produce a file that
+    still works after the checkout moves, so paths come back out relative."""
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(SystemExit):
+        cli_utils.resolve_config(
+            None, {"manifest": ("sub/pyproject.toml",), "rule": ("not_empty",), "print_config": True}
+        )
+
+    printed = yaml.safe_load(capsys.readouterr().out)
+    assert printed["project"]["manifests"][0]["path"] == "sub/pyproject.toml"
+    assert "root" not in printed["project"]
+
+
+def test_print_config_keeps_a_root_that_is_not_the_working_directory(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pkg").mkdir()
+
+    with pytest.raises(SystemExit):
+        cli_utils.resolve_config(
+            None, {"manifest": ("pyproject.toml",), "root": "pkg", "print_config": True}
+        )
+
+    printed = yaml.safe_load(capsys.readouterr().out)
+    assert printed["project"]["root"] == str(tmp_path / "pkg")
+    assert printed["project"]["manifests"][0]["path"] == "pyproject.toml"
+
+
+def test_print_config_leaves_a_manifest_outside_the_root_absolute(capsys, tmp_path, monkeypatch):
+    working_dir = tmp_path / "work"
+    working_dir.mkdir()
+    monkeypatch.chdir(working_dir)
+    outside = tmp_path / "elsewhere" / "pyproject.toml"
+
+    with pytest.raises(SystemExit):
+        cli_utils.resolve_config(None, {"manifest": (str(outside),), "print_config": True})
+
+    printed = yaml.safe_load(capsys.readouterr().out)
+    assert printed["project"]["manifests"][0]["path"] == str(outside)

--- a/test/configuration/test_from_cli.py
+++ b/test/configuration/test_from_cli.py
@@ -1,0 +1,203 @@
+import os
+
+import pytest
+
+from vertagus.configuration import from_cli
+from vertagus.errors import ConfigurationError
+
+
+def opts(**kwargs):
+    return from_cli.CliConfigOptions(**kwargs)
+
+
+def test_any_provided():
+    assert not opts().any_provided()
+    assert opts(manifest=("pyproject.toml",)).any_provided()
+    assert opts(rule=("not_empty",)).any_provided()
+    assert opts(tag_prefix="v").any_provided()
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("pyproject.toml", "setuptools_pyproject"),
+        ("src/pkg/pyproject.toml", "setuptools_pyproject"),
+        ("version.toml", "toml"),
+        ("version.yaml", "yaml"),
+        ("version.yml", "yaml"),
+        ("version.json", "json"),
+    ],
+)
+def test_infer_manifest_type(path, expected):
+    assert from_cli.infer_manifest_type(path) == expected
+
+
+def test_infer_manifest_type_unknown():
+    with pytest.raises(ConfigurationError, match="Could not determine the manifest type"):
+        from_cli.infer_manifest_type("VERSION")
+
+
+def test_parse_manifest_spec_bare_path():
+    manifest = from_cli.parse_manifest_spec("pyproject.toml", base_dir="/proj")
+    assert manifest == {
+        "name": "manifest_1",
+        "type": "setuptools_pyproject",
+        "path": os.path.abspath(os.path.join("/proj", "pyproject.toml")),
+        "loc": None,
+    }
+
+
+def test_parse_manifest_spec_fields():
+    manifest = from_cli.parse_manifest_spec(
+        "path=version.json,type=json,loc=project.version,name=api", index=2, base_dir="/proj"
+    )
+    assert manifest["name"] == "api"
+    assert manifest["type"] == "json"
+    assert manifest["loc"] == "project.version"
+    assert manifest["path"] == os.path.abspath(os.path.join("/proj", "version.json"))
+
+
+def test_parse_manifest_spec_defaults_name_by_index():
+    assert from_cli.parse_manifest_spec("a.json", index=1)["name"] == "manifest_2"
+
+
+def test_parse_manifest_spec_resolves_relative_to_cwd(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    manifest = from_cli.parse_manifest_spec("sub/version.yaml")
+    assert manifest["path"] == str(tmp_path / "sub" / "version.yaml")
+
+
+@pytest.mark.parametrize(
+    "spec, message",
+    [
+        ("", "the value is empty"),
+        ("type=json", "no path was given"),
+        ("path=a.json,bogus=1", "unknown key"),
+        ("path=a.json,justtext", "expected 'key=value' pairs"),
+    ],
+)
+def test_parse_manifest_spec_errors(spec, message):
+    with pytest.raises(ConfigurationError, match=message):
+        from_cli.parse_manifest_spec(spec)
+
+
+def test_parse_rule_spec_bare_name():
+    assert from_cli.parse_rule_spec("not_empty") == "not_empty"
+
+
+def test_parse_rule_spec_with_config():
+    assert from_cli.parse_rule_spec('regex:{"pattern": "^\\\\d+"}') == {
+        "type": "regex",
+        "config": {"pattern": "^\\d+"},
+    }
+
+
+@pytest.mark.parametrize(
+    "spec, message",
+    [
+        (":{}", "no rule name was given"),
+        ("regex:{not json}", "not valid JSON"),
+        ("regex:[1, 2]", "must be a JSON object"),
+    ],
+)
+def test_parse_rule_spec_errors(spec, message):
+    with pytest.raises(ConfigurationError, match=message):
+        from_cli.parse_rule_spec(spec)
+
+
+def test_build_master_config_defaults(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = from_cli.build_master_config(opts(manifest=("pyproject.toml",), rule=("not_empty", "any_increment")))
+    assert config["scm"] == {"type": "git"}
+    assert config["project"]["root"] == str(tmp_path)
+    assert config["project"]["rules"] == ["not_empty", "any_increment"]
+    assert config["project"]["manifests"][0]["path"] == str(tmp_path / "pyproject.toml")
+
+
+def test_build_master_config_full(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = from_cli.build_master_config(
+        opts(
+            manifest=("version.yaml",),
+            rule=("not_empty",),
+            alias=("string:latest",),
+            bumper="semver",
+            scm_type="git",
+            tag_prefix="v",
+            version_strategy="tag",
+            target_branch="main",
+            scm_manifest="path=other.yaml,type=yaml,loc=project.version",
+        )
+    )
+    assert config["scm"] == {
+        "type": "git",
+        "tag_prefix": "v",
+        "version_strategy": "tag",
+        "target_branch": "main",
+        "manifest_path": "other.yaml",
+        "manifest_type": "yaml",
+        "manifest_loc": "project.version",
+    }
+    assert config["project"]["aliases"] == ["string:latest"]
+    assert config["project"]["bumper"] == {"type": "semver"}
+
+
+def test_build_master_config_requires_a_manifest():
+    with pytest.raises(ConfigurationError, match="No manifests were configured"):
+        from_cli.build_master_config(opts(rule=("not_empty",)))
+
+
+def test_build_master_config_root_option(tmp_path):
+    config = from_cli.build_master_config(opts(manifest=("pyproject.toml",), root=str(tmp_path)))
+    assert config["project"]["root"] == str(tmp_path)
+    assert config["project"]["manifests"][0]["path"] == str(tmp_path / "pyproject.toml")
+
+
+def test_branch_strategy_defaults_scm_manifest_to_first_manifest(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = from_cli.build_master_config(
+        opts(manifest=("path=sub/version.yaml,loc=project.version",), version_strategy="branch", target_branch="main")
+    )
+    assert config["scm"]["manifest_path"] == os.path.join("sub", "version.yaml")
+    assert config["scm"]["manifest_type"] == "yaml"
+    assert config["scm"]["manifest_loc"] == "project.version"
+
+
+def test_branch_strategy_keeps_explicit_scm_manifest(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = from_cli.build_master_config(
+        opts(manifest=("version.yaml",), version_strategy="branch", scm_manifest="other.json")
+    )
+    assert config["scm"]["manifest_path"] == "other.json"
+    assert config["scm"]["manifest_type"] == "json"
+
+
+def test_tag_strategy_does_not_add_an_scm_manifest(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    config = from_cli.build_master_config(opts(manifest=("version.yaml",)))
+    assert "manifest_path" not in config["scm"]
+
+
+def test_merge_config_overrides_only_named_settings():
+    base = {
+        "scm": {"type": "git", "tag_prefix": "v", "target_branch": "main"},
+        "project": {
+            "root": "/proj",
+            "rules": ["not_empty", "any_increment"],
+            "manifests": [{"name": "pyproject", "type": "setuptools_pyproject", "path": "./pyproject.toml"}],
+            "stages": {"dev": {"rules": ["regex_dev_mmp"]}},
+        },
+    }
+    merged = from_cli.merge_config(base, opts(rule=("not_empty",), tag_prefix="release-"))
+
+    assert merged["scm"]["tag_prefix"] == "release-"
+    assert merged["scm"]["target_branch"] == "main"
+    assert merged["project"]["rules"] == ["not_empty"]
+    assert merged["project"]["manifests"] == base["project"]["manifests"]
+    assert merged["project"]["stages"] == base["project"]["stages"]
+
+
+def test_merge_config_does_not_mutate_the_base():
+    base = {"scm": {"type": "git"}, "project": {"rules": ["not_empty"]}}
+    from_cli.merge_config(base, opts(rule=("any_increment",)))
+    assert base["project"]["rules"] == ["not_empty"]

--- a/test/configuration/test_from_cli.py
+++ b/test/configuration/test_from_cli.py
@@ -158,9 +158,28 @@ def test_branch_strategy_defaults_scm_manifest_to_first_manifest(tmp_path, monke
     config = from_cli.build_master_config(
         opts(manifest=("path=sub/version.yaml,loc=project.version",), version_strategy="branch", target_branch="main")
     )
-    assert config["scm"]["manifest_path"] == os.path.join("sub", "version.yaml")
+    assert config["scm"]["manifest_path"] == "sub/version.yaml"
     assert config["scm"]["manifest_type"] == "yaml"
     assert config["scm"]["manifest_loc"] == "project.version"
+
+
+def test_branch_strategy_scm_manifest_is_relative_to_the_repository_not_the_project_root(tmp_path, monkeypatch):
+    """The scm reads its manifest with `git show <ref>:<path>`, which resolves against the
+    repository — the scm's root — while --root moves only the project."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "pkg").mkdir()
+
+    config = from_cli.build_master_config(
+        opts(
+            manifest=("pyproject.toml",),
+            root="pkg",
+            version_strategy="branch",
+            target_branch="main",
+        )
+    )
+
+    assert config["project"]["root"] == str(tmp_path / "pkg")
+    assert config["scm"]["manifest_path"] == "pkg/pyproject.toml"
 
 
 def test_branch_strategy_keeps_explicit_scm_manifest(tmp_path, monkeypatch):
@@ -201,3 +220,65 @@ def test_merge_config_does_not_mutate_the_base():
     base = {"scm": {"type": "git"}, "project": {"rules": ["not_empty"]}}
     from_cli.merge_config(base, opts(rule=("any_increment",)))
     assert base["project"]["rules"] == ["not_empty"]
+
+
+def test_merge_config_defaults_the_scm_manifest_like_a_configless_run(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    base = {"scm": {"type": "git", "target_branch": "main"}, "project": {"root": str(tmp_path)}}
+
+    merged = from_cli.merge_config(base, opts(manifest=("version.yaml",), version_strategy="branch"))
+
+    assert merged["scm"]["manifest_path"] == "version.yaml"
+    assert merged["scm"]["manifest_type"] == "yaml"
+
+
+def test_merge_config_keeps_the_files_scm_manifest(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    base = {
+        "scm": {"type": "git", "version_strategy": "branch", "manifest_path": "from_file.yaml", "manifest_type": "yaml"},
+        "project": {"root": str(tmp_path)},
+    }
+
+    merged = from_cli.merge_config(base, opts(manifest=("version.yaml",)))
+
+    assert merged["scm"]["manifest_path"] == "from_file.yaml"
+
+
+@pytest.mark.parametrize("flag, kwargs", [("--bumper", {"bumper": ""}), ("--target-branch", {"target_branch": ""})])
+def test_empty_scalar_options_are_rejected(flag, kwargs):
+    with pytest.raises(ConfigurationError, match=f"Invalid {flag}: the value is empty"):
+        from_cli.build_config_overlay(opts(**kwargs))
+
+
+def test_an_empty_tag_prefix_is_a_real_setting():
+    """`--tag-prefix ''` is how a run says "no tag prefix", so it has to count as configuration."""
+    assert opts(tag_prefix="").any_provided()
+    assert from_cli.build_config_overlay(opts(tag_prefix=""))["scm"]["tag_prefix"] == ""
+
+    merged = from_cli.merge_config({"scm": {"type": "git", "tag_prefix": "v"}, "project": {}}, opts(tag_prefix=""))
+    assert merged["scm"]["tag_prefix"] == ""
+
+
+def test_a_path_containing_an_equals_sign_can_be_written_as_a_spec(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    manifest = from_cli.parse_manifest_spec("path=ver=1/version.yaml")
+    assert manifest["path"] == str(tmp_path / "ver=1" / "version.yaml")
+
+
+def test_a_misspelled_key_is_not_silently_read_as_a_path():
+    """`pth=version.yaml` would otherwise infer a type from the extension and go looking
+    for a file of that name, rather than saying the key is wrong."""
+    with pytest.raises(ConfigurationError, match="must open with one of path, type, loc, name"):
+        from_cli.parse_manifest_spec("pth=version.yaml")
+
+
+def test_spec_keys_given_without_a_value_fall_back_to_their_defaults(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    manifest = from_cli.parse_manifest_spec("path=version.yaml,loc=,name=")
+    assert manifest["loc"] is None
+    assert manifest["name"] == "manifest_1"
+
+
+def test_scm_manifest_rejects_a_name():
+    with pytest.raises(ConfigurationError, match="unknown key 'name'"):
+        from_cli._parse_scm_manifest_spec("path=version.yaml,name=x")

--- a/test/core/test_project.py
+++ b/test/core/test_project.py
@@ -194,6 +194,20 @@ def test_project_init(test_project):
     assert test_project is not None
 
 
+def test_has_rules(test_project, mock_manifests, mock_stage):
+    assert test_project.has_rules() is True
+
+    ruleless = Project(
+        manifests=mock_manifests,
+        current_version_rules=[],
+        version_increment_rules=[],
+        manifest_versions_comparison_rules=[],
+        stages=[mock_stage],
+    )
+    assert ruleless.has_rules() is False
+    assert ruleless.has_rules(mock_stage.name) is True
+
+
 def test_get_version(test_project):
     assert test_project.get_version() == "0.0.0"
     with patch("vertagus.core.project.Project._get_manifests", MagicMock()) as mock_get_manifests:

--- a/test/test_operations.py
+++ b/test/test_operations.py
@@ -20,6 +20,35 @@ def test_validate_project_version():
     assert result is True
 
 
+def test_validate_project_version_warns_when_no_rules_are_configured():
+    """A validation with no rules passes unconditionally, which should not look like a pass."""
+    mock_scm = Mock(spec=ScmBase)
+    mock_scm.get_highest_version.return_value = 'v1.0.0'
+
+    mock_project = Mock(spec=Project)
+    mock_project.has_rules.return_value = False
+    mock_project.validate_version.return_value = True
+    mock_project.get_version.return_value = 'v1.0.1'
+
+    with patch('vertagus.operations.logger') as mock_logger:
+        assert validate_project_version(mock_scm, mock_project, 'stage1') is True
+        assert 'No rules are configured' in mock_logger.warning.call_args[0][0]
+
+
+def test_validate_project_version_does_not_warn_when_rules_exist():
+    mock_scm = Mock(spec=ScmBase)
+    mock_scm.get_highest_version.return_value = 'v1.0.0'
+
+    mock_project = Mock(spec=Project)
+    mock_project.has_rules.return_value = True
+    mock_project.validate_version.return_value = True
+    mock_project.get_version.return_value = 'v1.0.1'
+
+    with patch('vertagus.operations.logger') as mock_logger:
+        validate_project_version(mock_scm, mock_project, 'stage1')
+        mock_logger.warning.assert_not_called()
+
+
 def test_create_tags_normal():
     mock_scm = Mock(spec=ScmBase)
     mock_project = Mock(spec=Project)

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "vertagus"
-version = "0.5.0.dev1"
+version = "0.5.0.dev2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "vertagus"
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Every setting a `vertagus.yaml` can hold now has a corresponding CLI option, so a command can be configured entirely on the command line:

```bash
vertagus validate --manifest src/pyproject.toml --rule not_empty --rule any_increment
```

Supported by `validate`, `bump`, `create-tag`, `create-aliases`, `show-version` and `show-alias`.

## How

`configuration/from_cli.py` builds the same `MasterConfig` mapping that `configuration/load.py` reads from disk, so commands behave identically whichever way they were configured — no changes to the factory or core layers. `cli/options.py` provides a `@configless_options` decorator; each command passes the values to the new `cli_utils.resolve_config`, which picks one of three modes:

1. **No configuration options** — discovers and reads a config file, exactly as before.
2. **Options with `--config`** — the options override their counterparts in the file. Repeatable options replace the file's list rather than adding to it.
3. **Options without `--config`** — the options are the whole configuration, and *no* config file is discovered in the current directory, so an ad hoc run can't silently pick up settings the user didn't ask for.

Since stages are only definable in a config file, `--stage-name` requires one and otherwise errors with a message pointing at `--rule`.

## Option grammar

- `--manifest` / `--scm-manifest` take a bare path (manifest type inferred from the file name) or comma-separated `path=…,type=…,loc=…,name=…` pairs. Comma separation rather than colons keeps Windows paths like `C:\src\pyproject.toml` intact.
- `--rule` takes a rule name, optionally followed by `:` and a JSON object of rule config: `--rule 'custom_regex:{"pattern": "^1\..+"}'`.
- The rest map one to one: `--alias`, `--bumper`, `--root`, `--scm-type`, `--tag-prefix`, `--version-strategy`, `--target-branch`.

CLI manifest paths resolve against `--root`, or cwd otherwise, so they mean what you typed regardless of where a `--config` file lives. `--scm-manifest` is the exception and stays repo-relative, since git reads it via `git show branch:path`. Under `--version-strategy branch` with no `--scm-manifest`, the SCM defaults to the first `--manifest` — naming the same file twice is the common case.

## Also

- **`--print-config`** prints the configuration a command would run with and exits, so an ad hoc invocation can be grown into a real config file: `vertagus validate -m pyproject.toml --rule not_empty --print-config > vertagus.yaml`.
- Fixes a pre-existing bug: `create-tag` and `create-aliases` defaulted `--config` to a hardcoded `vertagus.toml` path, and `create-aliases` bypassed the shared loader entirely. Both now use the normal discovery path.

## Tests & docs

- `test/configuration/test_from_cli.py` covers spec parsing, type inference, error messages and config assembly; `test_cli_utils.py` covers the three resolution modes; `test_cli_validate.py` covers configless, override and error paths end to end. 242 tests pass, ruff clean.
- New "Configuration-Free Usage" section in `docs/cli-reference.md`, with additions to `getting-started.md`, `index.md`, `configuration.md`, the README, and a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)