### PR TITLE
Preserve comments and formatting when bumping a TOML or YAML version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ CHANGELOG
 0.5.0
 ---
 
+**Fixes.**
+
+* **Bumping a version in a TOML manifest no longer strips the file's comments and formatting.** `vertagus bump` previously reserialized the entire document, which discarded every comment and blank line and reflowed the file's arrays and quoting — a whole-file diff for a change of a few characters. The version is now rewritten in place, leaving every other byte of the file untouched. If the version cannot be located and replaced safely, vertagus logs a warning and falls back to the previous whole-file rewrite. YAML and JSON manifests are still rewritten in full.
+
 **Breaking changes.**
 
 * **Rules are now configured as a flat list.** The `rules` block is no longer split into `current`, `increment`, and `manifest_comparisons` sub-keys. List every rule directly under `rules`; vertagus infers from the rule class whether it validates a single version or compares versions. A 0.4.x-style mapping is detected and raises an error explaining the migration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 
 **Fixes.**
 
-* **Bumping a version in a TOML manifest no longer strips the file's comments and formatting.** `vertagus bump` previously reserialized the entire document, which discarded every comment and blank line and reflowed the file's arrays and quoting — a whole-file diff for a change of a few characters. The version is now rewritten in place, leaving every other byte of the file untouched. If the version cannot be located and replaced safely, vertagus logs a warning and falls back to the previous whole-file rewrite. YAML and JSON manifests are still rewritten in full.
+* **Bumping a version in a TOML or YAML manifest no longer strips the file's comments and formatting.** `vertagus bump` previously reserialized the entire document, which discarded every comment and blank line and reflowed the file's collections, quoting and indentation — a whole-file diff for a change of a few characters. The version is now rewritten in place, leaving every other byte of the file untouched. If the version cannot be located and replaced safely, vertagus logs a warning and falls back to the previous whole-file rewrite. In YAML, the replacement is always quoted so that a version like `1.0` cannot be rewritten as a float. JSON manifests, which have no comments to lose, are still rewritten in full.
 
 **Breaking changes.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vertagus"
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
 description = "A tool to assist the maintenance of package versioning via manifests and source control."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/vertagus/providers/manifest/in_place.py
+++ b/src/vertagus/providers/manifest/in_place.py
@@ -1,0 +1,79 @@
+"""Shared machinery for updating a manifest's version without rewriting the whole file."""
+
+import typing as T
+from logging import getLogger
+
+
+logger = getLogger(__name__)
+
+
+class InPlaceVersionWriter:
+    """Writes a new version into a manifest by editing the text of the file.
+
+    Serializing a parsed document back to text loses everything the parser threw away:
+    comments, blank lines, key order, and the author's choice of quoting and indentation.
+    A version bump changes a handful of characters and has no business reflowing a file,
+    so manifests that can be edited in place do that instead.
+
+    Subclasses supply a parser and an editor for their format. Every edit is checked
+    before it lands: an editor that cannot place the version returns ``None``, and an
+    edit whose text does not parse back to the original data with only the version
+    changed is discarded. Either outcome falls back to rewriting the whole document, so
+    the worst case is the behavior of a format that cannot be edited in place at all.
+    """
+
+    def _parse_text(self, text: str) -> T.Any:
+        """Parse a document, raising this format's parse error if it is malformed."""
+        raise NotImplementedError
+
+    def _replace_version_text(self, text: str, loc: T.Sequence[str | int], version: str) -> str | None:
+        """Return ``text`` with the version at ``loc`` replaced, or None to decline."""
+        raise NotImplementedError
+
+    def _write_version_in_place(self, version: str) -> bool:
+        """Rewrite just the version in the file on disk, leaving the rest of it untouched.
+
+        Returns False when the version could not be replaced safely, so that the caller
+        can fall back to rewriting the whole document.
+        """
+        path = self._full_path()  # type: ignore[attr-defined]
+        with open(path, encoding="utf-8", newline="") as f:
+            original = f.read()
+
+        try:
+            edited = self._replace_version_text(original, self.loc, version)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001 - an editor bug must never corrupt a manifest
+            logger.debug(f"Failed to edit the version in {path} in place", exc_info=True)
+            return False
+        if edited is None or not self._edit_is_faithful(original, edited, version):
+            return False
+
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(edited)
+        return True
+
+    def _edit_is_faithful(self, original: str, edited: str, version: str) -> bool:
+        """Whether an edited document parses to the original data with only the version changed."""
+        loc = self.loc  # type: ignore[attr-defined]
+        try:
+            edited_doc = self._parse_text(edited)
+            expected_doc = self._parse_text(original)
+        except Exception:  # noqa: BLE001 - any parse failure means the edit is not trustworthy
+            return False
+        p = expected_doc
+        try:
+            for k in loc[:-1]:
+                p = p[k]
+            p[loc[-1]] = version
+        except (KeyError, IndexError, TypeError):
+            return False
+        return edited_doc == expected_doc
+
+    def _write_version(self, version: str) -> None:
+        """Write the version, preferring an in-place edit and warning when falling back."""
+        if not self._write_version_in_place(version):
+            logger.warning(
+                f"Could not update the version in place in {self._full_path()}; rewriting the whole "  # type: ignore[attr-defined]
+                "file. Comments and formatting in this file may not be preserved."
+            )
+            self._write_doc()  # type: ignore[attr-defined]

--- a/src/vertagus/providers/manifest/toml_edit.py
+++ b/src/vertagus/providers/manifest/toml_edit.py
@@ -1,0 +1,223 @@
+"""Edit a single value in a TOML document without disturbing the rest of it.
+
+Serializing a parsed TOML document back to text loses everything the parser threw
+away: comments, blank lines, key order, and the author's choice of quoting and
+indentation. That is an unacceptable trade for a version bump, which changes a
+handful of characters, so vertagus rewrites the version in place instead.
+
+The scanner here understands just enough TOML to find the span of text holding a
+value: table headers, dotted keys, and the string, array and inline-table forms a
+value can take. Anything it does not recognize makes it give up and return
+``None`` rather than guess, which lets the caller fall back to a full rewrite.
+"""
+
+import typing as T
+
+_BARE_KEY_CHARS = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-")
+_WHITESPACE = " \t"
+
+
+class _Unparseable(Exception):
+    """Raised when the scanner meets TOML it does not model."""
+
+
+class _KeyValue(T.NamedTuple):
+    path: tuple[str, ...]
+    value_start: int
+    value_end: int
+
+
+def replace_value(text: str, path: T.Sequence[str], new_value: str) -> str | None:
+    """Replace the value at ``path`` with ``new_value``, quoted as a TOML basic string.
+
+    Returns the edited document, or ``None`` if the key could not be located
+    unambiguously. Every byte outside the replaced value is preserved exactly.
+    """
+    target = tuple(path)
+    try:
+        matches = [kv for kv in _iter_key_values(text) if kv.path == target]
+    except _Unparseable:
+        return None
+    if len(matches) != 1:
+        return None
+
+    match = matches[0]
+    return text[: match.value_start] + _format_basic_string(new_value) + text[match.value_end :]
+
+
+def _format_basic_string(value: str) -> str:
+    """Render a string as a TOML basic string."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    for char, escape in (("\b", "\\b"), ("\t", "\\t"), ("\n", "\\n"), ("\f", "\\f"), ("\r", "\\r")):
+        escaped = escaped.replace(char, escape)
+    escaped = "".join(c if c >= " " and c != "\x7f" else f"\\u{ord(c):04x}" for c in escaped)
+    return f'"{escaped}"'
+
+
+def _iter_key_values(text: str) -> T.Iterator[_KeyValue]:
+    """Yield every key/value assignment in the document, with its fully qualified path.
+
+    Keys inside arrays of tables are yielded under a path that cannot be addressed by
+    a vertagus ``loc`` (which names dict keys only), so they can never be matched.
+    """
+    index = 0
+    length = len(text)
+    table: tuple[str, ...] = ()
+    in_array_of_tables = False
+
+    while index < length:
+        char = text[index]
+        if char in _WHITESPACE or char in "\r\n":
+            index += 1
+            continue
+        if char == "#":
+            index = _skip_to_end_of_line(text, index)
+            continue
+        if char == "[":
+            table, in_array_of_tables, index = _scan_table_header(text, index)
+            continue
+
+        path, value_start, value_end, index = _scan_key_value(text, index)
+        if not in_array_of_tables:
+            yield _KeyValue(table + path, value_start, value_end)
+
+
+def _scan_table_header(text: str, index: int) -> tuple[tuple[str, ...], bool, int]:
+    """Scan a ``[table]`` or ``[[array.of.tables]]`` header."""
+    is_array_of_tables = text.startswith("[[", index)
+    index += 2 if is_array_of_tables else 1
+    path, index = _scan_key_path(text, index)
+    index = _skip_whitespace(text, index)
+    closing = "]]" if is_array_of_tables else "]"
+    if not text.startswith(closing, index):
+        raise _Unparseable(f"Unterminated table header at offset {index}")
+    return path, is_array_of_tables, index + len(closing)
+
+
+def _scan_key_value(text: str, index: int) -> tuple[tuple[str, ...], int, int, int]:
+    """Scan a ``key = value`` assignment, returning the key path and the value's span."""
+    path, index = _scan_key_path(text, index)
+    index = _skip_whitespace(text, index)
+    if index >= len(text) or text[index] != "=":
+        raise _Unparseable(f"Expected '=' after key at offset {index}")
+    index = _skip_whitespace(text, index + 1)
+    value_start = index
+    value_end = _scan_value(text, index)
+    return path, value_start, value_end, value_end
+
+
+def _scan_key_path(text: str, index: int) -> tuple[tuple[str, ...], int]:
+    """Scan a possibly dotted key, whose parts may be bare or quoted."""
+    parts: list[str] = []
+    while True:
+        index = _skip_whitespace(text, index)
+        if index >= len(text):
+            raise _Unparseable("Document ended inside a key")
+        char = text[index]
+        if char in ("'", '"'):
+            end = _scan_quoted_string(text, index)
+            parts.append(text[index + 1 : end - 1])
+            index = end
+        else:
+            start = index
+            while index < len(text) and text[index] in _BARE_KEY_CHARS:
+                index += 1
+            if index == start:
+                raise _Unparseable(f"Expected a key at offset {index}")
+            parts.append(text[start:index])
+        index = _skip_whitespace(text, index)
+        if index < len(text) and text[index] == ".":
+            index += 1
+            continue
+        return tuple(parts), index
+
+
+def _scan_value(text: str, index: int) -> int:
+    """Return the offset just past the value beginning at ``index``."""
+    if index >= len(text):
+        raise _Unparseable("Document ended where a value was expected")
+    char = text[index]
+    if char in ("'", '"'):
+        return _scan_quoted_string(text, index)
+    if char == "[":
+        return _scan_bracketed(text, index, "[", "]")
+    if char == "{":
+        return _scan_bracketed(text, index, "{", "}")
+    return _scan_bare_value(text, index)
+
+
+def _scan_quoted_string(text: str, index: int) -> int:
+    """Scan a basic, literal, or multi-line string, returning the offset past its close."""
+    quote = text[index]
+    if text.startswith(quote * 3, index):
+        delimiter = quote * 3
+        escapes = quote == '"'
+        index += 3
+    else:
+        delimiter = quote
+        escapes = quote == '"'
+        index += 1
+
+    while index < len(text):
+        char = text[index]
+        if escapes and char == "\\":
+            index += 2
+            continue
+        if text.startswith(delimiter, index):
+            index += len(delimiter)
+            # A multi-line string may end with up to two extra quote characters.
+            if len(delimiter) == 3:
+                extra = 0
+                while extra < 2 and index < len(text) and text[index] == quote:
+                    index += 1
+                    extra += 1
+            return index
+        if len(delimiter) == 1 and char in "\r\n":
+            raise _Unparseable(f"Unterminated string at offset {index}")
+        index += 1
+    raise _Unparseable("Document ended inside a string")
+
+
+def _scan_bracketed(text: str, index: int, opening: str, closing: str) -> int:
+    """Scan an array or inline table, skipping over nested values, strings and comments."""
+    depth = 0
+    while index < len(text):
+        char = text[index]
+        if char in ("'", '"'):
+            index = _scan_quoted_string(text, index)
+            continue
+        if char == "#":
+            index = _skip_to_end_of_line(text, index)
+            continue
+        if char == opening:
+            depth += 1
+        elif char == closing:
+            depth -= 1
+            if depth == 0:
+                return index + 1
+        index += 1
+    raise _Unparseable(f"Unterminated {opening!r} at offset {index}")
+
+
+def _scan_bare_value(text: str, index: int) -> int:
+    """Scan a number, boolean or date, which runs to a comment or the end of the line."""
+    end = index
+    while end < len(text) and text[end] not in "\r\n#":
+        end += 1
+    value = text[index:end]
+    trimmed = value.rstrip(_WHITESPACE)
+    if not trimmed:
+        raise _Unparseable(f"Empty value at offset {index}")
+    return index + len(trimmed)
+
+
+def _skip_whitespace(text: str, index: int) -> int:
+    while index < len(text) and text[index] in _WHITESPACE:
+        index += 1
+    return index
+
+
+def _skip_to_end_of_line(text: str, index: int) -> int:
+    while index < len(text) and text[index] not in "\r\n":
+        index += 1
+    return index

--- a/src/vertagus/providers/manifest/toml_manifest.py
+++ b/src/vertagus/providers/manifest/toml_manifest.py
@@ -1,15 +1,13 @@
 from vertagus.core.manifest_base import ManifestBase
 from . import toml_edit
+from .in_place import InPlaceVersionWriter
 import tomllib
 import tomli_w
 import os.path
-from logging import getLogger
+import typing as T
 
 
-logger = getLogger(__name__)
-
-
-class TomlManifest(ManifestBase):
+class TomlManifest(InPlaceVersionWriter, ManifestBase):
     manifest_type: str = "toml"
     description: str = "A TOML file. Users provide a custom `loc` to the version as a list of keys."
 
@@ -40,36 +38,11 @@ class TomlManifest(ManifestBase):
         with open(path, "wb") as f:
             tomli_w.dump(self._doc, f)
 
-    def _write_version_in_place(self, version: str) -> bool:
-        """Rewrite just the version in the file on disk, leaving the rest of it untouched.
+    def _parse_text(self, text: str) -> dict:
+        return tomllib.loads(text)
 
-        Returns False when the version could not be located and replaced safely, so that
-        the caller can fall back to rewriting the whole document.
-        """
-        path = self._full_path()
-        with open(path, encoding="utf-8", newline="") as f:
-            original = f.read()
-
-        edited = toml_edit.replace_value(original, self.loc, version)
-        if edited is None or not self._edit_is_faithful(original, edited, version):
-            return False
-
-        with open(path, "w", encoding="utf-8", newline="") as f:
-            f.write(edited)
-        return True
-
-    def _edit_is_faithful(self, original: str, edited: str, version: str) -> bool:
-        """Whether an edited document parses to the original data with only the version changed."""
-        try:
-            edited_doc = tomllib.loads(edited)
-            expected_doc = tomllib.loads(original)
-        except tomllib.TOMLDecodeError:
-            return False
-        p = expected_doc
-        for k in self.loc[:-1]:
-            p = p[k]
-        p[self.loc[-1]] = version
-        return edited_doc == expected_doc
+    def _replace_version_text(self, text: str, loc: T.Sequence[str | int], version: str) -> str | None:
+        return toml_edit.replace_value(text, [str(k) for k in loc], version)
 
     @classmethod
     def version_from_content(
@@ -95,9 +68,4 @@ class TomlManifest(ManifestBase):
             p = p[k]
         p[self.loc[-1]] = version
         if write:
-            if not self._write_version_in_place(version):
-                logger.warning(
-                    f"Could not update the version in place in {self._full_path()}; rewriting the whole "
-                    "file. Comments and formatting in this file may not be preserved."
-                )
-                self._write_doc()
+            self._write_version(version)

--- a/src/vertagus/providers/manifest/toml_manifest.py
+++ b/src/vertagus/providers/manifest/toml_manifest.py
@@ -1,7 +1,12 @@
 from vertagus.core.manifest_base import ManifestBase
+from . import toml_edit
 import tomllib
 import tomli_w
 import os.path
+from logging import getLogger
+
+
+logger = getLogger(__name__)
 
 
 class TomlManifest(ManifestBase):
@@ -30,9 +35,41 @@ class TomlManifest(ManifestBase):
         return path
 
     def _write_doc(self):
+        """Rewrite the whole document from the parsed data, losing comments and formatting."""
         path = self._full_path()
         with open(path, "wb") as f:
             tomli_w.dump(self._doc, f)
+
+    def _write_version_in_place(self, version: str) -> bool:
+        """Rewrite just the version in the file on disk, leaving the rest of it untouched.
+
+        Returns False when the version could not be located and replaced safely, so that
+        the caller can fall back to rewriting the whole document.
+        """
+        path = self._full_path()
+        with open(path, encoding="utf-8", newline="") as f:
+            original = f.read()
+
+        edited = toml_edit.replace_value(original, self.loc, version)
+        if edited is None or not self._edit_is_faithful(original, edited, version):
+            return False
+
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(edited)
+        return True
+
+    def _edit_is_faithful(self, original: str, edited: str, version: str) -> bool:
+        """Whether an edited document parses to the original data with only the version changed."""
+        try:
+            edited_doc = tomllib.loads(edited)
+            expected_doc = tomllib.loads(original)
+        except tomllib.TOMLDecodeError:
+            return False
+        p = expected_doc
+        for k in self.loc[:-1]:
+            p = p[k]
+        p[self.loc[-1]] = version
+        return edited_doc == expected_doc
 
     @classmethod
     def version_from_content(
@@ -58,4 +95,9 @@ class TomlManifest(ManifestBase):
             p = p[k]
         p[self.loc[-1]] = version
         if write:
-            self._write_doc()
+            if not self._write_version_in_place(version):
+                logger.warning(
+                    f"Could not update the version in place in {self._full_path()}; rewriting the whole "
+                    "file. Comments and formatting in this file may not be preserved."
+                )
+                self._write_doc()

--- a/src/vertagus/providers/manifest/yaml_edit.py
+++ b/src/vertagus/providers/manifest/yaml_edit.py
@@ -1,0 +1,206 @@
+"""Edit a single scalar in a YAML document without disturbing the rest of it.
+
+The counterpart to :mod:`vertagus.providers.manifest.toml_edit`, and written to the
+same rule: locate the span of text holding a value and touch nothing else, or decline
+by returning ``None`` so the caller can fall back to a full rewrite.
+
+YAML is a far larger language than a version bump needs, so this models only the block
+mappings that manifests are written in. Anchors, tags, flow collections, block scalars
+and multiple documents are all recognized well enough to be refused rather than
+misread.
+"""
+
+import typing as T
+
+_WHITESPACE = " \t"
+
+
+class _Unparseable(Exception):
+    """Raised when the scanner meets YAML it does not model."""
+
+
+class _Scalar(T.NamedTuple):
+    path: tuple[str, ...]
+    start: int
+    end: int
+    addressable: bool
+
+
+def replace_value(text: str, path: T.Sequence[str], new_value: str) -> str | None:
+    """Replace the scalar at ``path`` with ``new_value``, quoted as a YAML string.
+
+    Returns the edited document, or ``None`` if the key could not be located
+    unambiguously. Every byte outside the replaced scalar is preserved exactly.
+    """
+    if any(c in new_value for c in "\r\n") or any(c < " " for c in new_value):
+        return None
+
+    target = tuple(path)
+    try:
+        matches = [s for s in _iter_scalars(text) if s.path == target and s.addressable]
+    except _Unparseable:
+        return None
+    if len(matches) != 1:
+        return None
+
+    match = matches[0]
+    quoted = _quote_like(text[match.start : match.end], new_value)
+    return text[: match.start] + quoted + text[match.end :]
+
+
+def _quote_like(original: str, value: str) -> str:
+    """Quote ``value`` in the style of the scalar it replaces, defaulting to single quotes.
+
+    A version is always quoted, even where the original was plain: unquoted ``1.0`` is a
+    float to a YAML parser, and a bump must not change a value's type.
+    """
+    if original.startswith('"'):
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        return f'"{escaped}"'
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _iter_scalars(text: str) -> T.Iterator[_Scalar]:
+    """Yield every ``key: scalar`` assignment in the document, with its path.
+
+    Keys nested inside a sequence are yielded as unaddressable: a vertagus ``loc`` names
+    mapping keys only, so such a key is never a legitimate target and must not be matched
+    by one that happens to share its name.
+    """
+    lines = text.splitlines(keepends=True)
+    offset = 0
+    stack: list[tuple[int, str]] = []
+    sequence_indent: int | None = None
+    seen_content = False
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        line_start = offset
+        offset += len(line)
+        index += 1
+
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if stripped.startswith("---") or stripped.startswith("..."):
+            if seen_content:
+                raise _Unparseable("Multiple documents are not modelled")
+            continue
+
+        content = line.rstrip("\r\n")
+        indent = len(content) - len(content.lstrip(" "))
+        if "\t" in content[:indent]:
+            raise _Unparseable("Tab indentation is not modelled")
+        seen_content = True
+
+        while stack and stack[-1][0] >= indent:
+            stack.pop()
+        if sequence_indent is not None and indent <= sequence_indent:
+            sequence_indent = None
+
+        body = content[indent:]
+        if body.startswith("-"):
+            sequence_indent = indent if sequence_indent is None else min(sequence_indent, indent)
+            continue
+
+        key, key_end = _scan_key(body)
+        path = tuple(k for _, k in stack) + (key,)
+        value = body[key_end:]
+        value_offset = key_end + len(value) - len(value.lstrip(_WHITESPACE))
+        value = value.strip()
+
+        if not value or value.startswith("#"):
+            stack.append((indent, key))
+            continue
+        if value[0] in "&*!":
+            raise _Unparseable("Anchors, aliases and tags are not modelled")
+        if value[0] in "[{":
+            raise _Unparseable("Flow collections are not modelled")
+        if value[0] in "|>":
+            index, offset = _skip_block_scalar(lines, index, offset, indent)
+            continue
+
+        start = line_start + indent + value_offset
+        yield _Scalar(path, start, start + _scalar_length(content[indent + value_offset :]), sequence_indent is None)
+
+
+def _scan_key(body: str) -> tuple[str, int]:
+    """Scan a mapping key, returning it and the offset just past its colon."""
+    if body[0] in ("'", '"'):
+        end = _scan_quoted(body, 0)
+        key = _unquote(body[:end])
+        rest = end
+    else:
+        rest = _find_key_separator(body)
+        key = body[:rest].rstrip(_WHITESPACE)
+        if not key:
+            raise _Unparseable("Empty mapping key")
+        return key, rest + 1
+
+    while rest < len(body) and body[rest] in _WHITESPACE:
+        rest += 1
+    if rest >= len(body) or body[rest] != ":":
+        raise _Unparseable("Expected ':' after a quoted key")
+    return key, rest + 1
+
+
+def _find_key_separator(body: str) -> int:
+    """Find the ``:`` that ends a plain key: one at the end of the line or followed by a space."""
+    for i, char in enumerate(body):
+        if char == "#" and i and body[i - 1] in _WHITESPACE:
+            break
+        if char == ":" and (i + 1 == len(body) or body[i + 1] in _WHITESPACE):
+            return i
+    raise _Unparseable(f"Not a mapping entry: {body!r}")
+
+
+def _scalar_length(value: str) -> int:
+    """Return the length of the scalar at the start of ``value``, excluding any comment."""
+    if value[0] in ("'", '"'):
+        return _scan_quoted(value, 0)
+    end = len(value)
+    for i, char in enumerate(value):
+        if char == "#" and i and value[i - 1] in _WHITESPACE:
+            end = i
+            break
+    return len(value[:end].rstrip(_WHITESPACE))
+
+
+def _scan_quoted(text: str, index: int) -> int:
+    """Scan a quoted scalar, returning the offset just past its closing quote."""
+    quote = text[index]
+    index += 1
+    while index < len(text):
+        char = text[index]
+        if quote == '"' and char == "\\":
+            index += 2
+            continue
+        if char == quote:
+            if quote == "'" and index + 1 < len(text) and text[index + 1] == "'":
+                index += 2
+                continue
+            return index + 1
+        index += 1
+    raise _Unparseable("Unterminated quoted scalar")
+
+
+def _unquote(text: str) -> str:
+    """Return the value of a quoted scalar."""
+    if text.startswith("'"):
+        return text[1:-1].replace("''", "'")
+    return text[1:-1].replace('\\"', '"').replace("\\\\", "\\")
+
+
+def _skip_block_scalar(lines: list[str], index: int, offset: int, indent: int) -> tuple[int, int]:
+    """Skip the body of a ``|`` or ``>`` block scalar, which is indented past its key."""
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        if stripped:
+            content = line.rstrip("\r\n")
+            if len(content) - len(content.lstrip(" ")) <= indent:
+                break
+        offset += len(line)
+        index += 1
+    return index, offset

--- a/src/vertagus/providers/manifest/yaml_manifest.py
+++ b/src/vertagus/providers/manifest/yaml_manifest.py
@@ -1,9 +1,12 @@
 from vertagus.core.manifest_base import ManifestBase
+from . import yaml_edit
+from .in_place import InPlaceVersionWriter
 import yaml
 import os.path
+import typing as T
 
 
-class YamlManifest(ManifestBase):
+class YamlManifest(InPlaceVersionWriter, ManifestBase):
     manifest_type: str = "yaml"
     description: str = "A YAML file. Users provide a custom `loc` to the version as a list of keys."
 
@@ -36,9 +39,16 @@ class YamlManifest(ManifestBase):
         return path
 
     def _write_doc(self):
+        """Rewrite the whole document from the parsed data, losing comments and formatting."""
         path = self._full_path()
         with open(path, "w") as f:
             yaml.safe_dump(self._doc, f, default_flow_style=False)
+
+    def _parse_text(self, text: str):
+        return yaml.safe_load(text)
+
+    def _replace_version_text(self, text: str, loc: T.Sequence[str | int], version: str) -> str | None:
+        return yaml_edit.replace_value(text, [str(k) for k in loc], version)
 
     @classmethod
     def version_from_content(
@@ -64,4 +74,4 @@ class YamlManifest(ManifestBase):
             p = p[k]
         p[self.loc[-1]] = version
         if write:
-            self._write_doc()
+            self._write_version(version)

--- a/test/providers/manifest/test_toml_edit.py
+++ b/test/providers/manifest/test_toml_edit.py
@@ -1,0 +1,128 @@
+import tomllib
+
+import pytest
+
+from vertagus.providers.manifest import toml_edit
+
+
+def test_replaces_only_the_targeted_value():
+    text = '[project]\nname = "pkg"\nversion = "0.1.0"  # the version\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '[project]\nname = "pkg"\nversion = "0.2.0"  # the version\n'
+
+
+def test_preserves_comments_blank_lines_and_formatting():
+    text = (
+        "# A leading comment\n"
+        "\n"
+        "[project]  # trailing comment on a header\n"
+        "# a comment about the version\n"
+        "version   =    '0.1.0'\n"
+        "\n"
+        "classifiers = [\n"
+        '    "One",  # first\n'
+        '    "Two",\n'
+        "]\n"
+    )
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == text.replace("'0.1.0'", '"0.2.0"')
+    assert edited.count("#") == text.count("#")
+
+
+def test_preserves_crlf_line_endings():
+    text = '[project]\r\nversion = "0.1.0"\r\nname = "pkg"\r\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '[project]\r\nversion = "0.2.0"\r\nname = "pkg"\r\n'
+
+
+def test_top_level_key():
+    text = 'version = "0.1.0"\n[project]\nname = "pkg"\n'
+    edited = toml_edit.replace_value(text, ["version"], "0.2.0")
+    assert edited == 'version = "0.2.0"\n[project]\nname = "pkg"\n'
+
+
+def test_dotted_key():
+    text = '# comment\nproject.version = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '# comment\nproject.version = "0.2.0"\n'
+
+
+def test_dotted_key_inside_a_table():
+    text = '[tool]\nvertagus.version = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["tool", "vertagus", "version"], "0.2.0")
+    assert edited == '[tool]\nvertagus.version = "0.2.0"\n'
+
+
+def test_quoted_key():
+    text = '[project]\n"my.version" = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["project", "my.version"], "0.2.0")
+    assert edited == '[project]\n"my.version" = "0.2.0"\n'
+
+
+def test_nested_table():
+    text = '[a.b]\nversion = "0.1.0"\n[a.c]\nversion = "9.9.9"\n'
+    edited = toml_edit.replace_value(text, ["a", "b", "version"], "0.2.0")
+    assert edited == '[a.b]\nversion = "0.2.0"\n[a.c]\nversion = "9.9.9"\n'
+
+
+def test_multiline_string_value_is_replaced():
+    text = '[project]\nversion = """0.1.0"""\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '[project]\nversion = "0.2.0"\n'
+
+
+def test_a_key_inside_a_multiline_string_is_not_mistaken_for_an_assignment():
+    text = '[project]\nreadme = """\n[project]\nversion = "9.9.9"\n"""\nversion = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == text.replace('version = "0.1.0"', 'version = "0.2.0"')
+    assert '"9.9.9"' in edited
+
+
+def test_a_key_inside_an_inline_table_is_scoped_to_it():
+    text = '[project]\nauthor = { name = "x", version = "9.9.9" }\nversion = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == text.replace('version = "0.1.0"', 'version = "0.2.0"')
+
+
+def test_array_of_tables_keys_are_not_matched():
+    text = '[[project]]\nversion = "0.1.0"\n'
+    assert toml_edit.replace_value(text, ["project", "version"], "0.2.0") is None
+
+
+def test_missing_key_returns_none():
+    text = '[project]\nname = "pkg"\n'
+    assert toml_edit.replace_value(text, ["project", "version"], "0.2.0") is None
+
+
+def test_duplicate_matches_return_none():
+    # Not valid TOML, but the scanner must not pick one arbitrarily.
+    text = '[project]\nversion = "0.1.0"\n[project]\nversion = "0.1.0"\n'
+    assert toml_edit.replace_value(text, ["project", "version"], "0.2.0") is None
+
+
+def test_malformed_document_returns_none():
+    assert toml_edit.replace_value('[project\nversion = "0.1.0"\n', ["project", "version"], "0.2.0") is None
+    assert toml_edit.replace_value('[project]\nversion "0.1.0"\n', ["project", "version"], "0.2.0") is None
+    assert toml_edit.replace_value('[project]\nversion = "0.1.0\n', ["project", "version"], "0.2.0") is None
+
+
+@pytest.mark.parametrize(
+    "version",
+    ["1.0.0", '1.0.0+build"quoted"', "1.0.0+back\\slash", "1.0.0.dev0"],
+)
+def test_written_values_round_trip(version):
+    text = '[project]\nversion = "0.1.0"\n'
+    edited = toml_edit.replace_value(text, ["project", "version"], version)
+    assert tomllib.loads(edited)["project"]["version"] == version
+
+
+def test_replaces_non_string_values():
+    text = "[project]\nversion = 1\n"
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '[project]\nversion = "0.2.0"\n'
+
+
+def test_replaces_a_value_followed_by_a_comment_without_eating_it():
+    text = "[project]\nversion = 1  # a number, oddly\n"
+    edited = toml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == '[project]\nversion = "0.2.0"  # a number, oddly\n'

--- a/test/providers/manifest/test_toml_manifest.py
+++ b/test/providers/manifest/test_toml_manifest.py
@@ -38,3 +38,54 @@ def test_update_version():
     assert manifest.version == "1.0.0"
     manifest.update_version("2.0.0", write=False)
     assert manifest.version == "2.0.0"
+
+
+_PYPROJECT = '''\
+# The build system
+[build-system]
+requires = ["setuptools"]  # keep it minimal
+
+[project]
+name = "pkg"
+version = "1.0.0"
+dependencies = [
+    "click",  # the CLI framework
+]
+'''
+
+
+@pytest.fixture
+def toml_file(tmp_path, patch_load_doc):
+    path = tmp_path / "pyproject.toml"
+    path.write_text(_PYPROJECT)
+    return path
+
+
+def test_update_version_preserves_comments_and_formatting(toml_file):
+    manifest = TomlManifest("test", str(toml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"version": "1.0.0"}, "build-system": {"requires": ["setuptools"]}}
+
+    manifest.update_version("2.0.0")
+
+    assert toml_file.read_text() == _PYPROJECT.replace('version = "1.0.0"', 'version = "2.0.0"')
+
+
+def test_update_version_falls_back_to_a_full_rewrite(toml_file, caplog):
+    # The version is absent from the file, so it cannot be replaced in place.
+    toml_file.write_text('[project]\nname = "pkg"\n')
+    manifest = TomlManifest("test", str(toml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"name": "pkg"}}
+
+    manifest.update_version("2.0.0")
+
+    assert 'version = "2.0.0"' in toml_file.read_text()
+    assert "may not be preserved" in caplog.text
+
+
+def test_update_version_leaves_the_file_alone_when_not_writing(toml_file):
+    manifest = TomlManifest("test", str(toml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"version": "1.0.0"}}
+
+    manifest.update_version("2.0.0", write=False)
+
+    assert toml_file.read_text() == _PYPROJECT

--- a/test/providers/manifest/test_yaml_edit.py
+++ b/test/providers/manifest/test_yaml_edit.py
@@ -1,0 +1,120 @@
+import yaml
+
+import pytest
+
+from vertagus.providers.manifest import yaml_edit
+
+
+def test_replaces_only_the_targeted_value():
+    text = "project:\n  name: pkg\n  version: 0.1.0  # the version\n"
+    edited = yaml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == "project:\n  name: pkg\n  version: '0.2.0'  # the version\n"
+
+
+def test_preserves_comments_blank_lines_and_formatting():
+    text = (
+        "# A leading comment\n"
+        "\n"
+        "project:  # the project\n"
+        "  # a comment about the version\n"
+        "  version:    '0.1.0'\n"
+        "\n"
+        "  deps:\n"
+        "    - click  # the CLI framework\n"
+    )
+    edited = yaml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == text.replace("'0.1.0'", "'0.2.0'")
+    assert edited.count("#") == text.count("#")
+
+
+def test_preserves_crlf_line_endings():
+    text = "project:\r\n  version: 0.1.0\r\n  name: pkg\r\n"
+    edited = yaml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == "project:\r\n  version: '0.2.0'\r\n  name: pkg\r\n"
+
+
+def test_top_level_key():
+    text = "version: 0.1.0\nname: pkg\n"
+    edited = yaml_edit.replace_value(text, ["version"], "0.2.0")
+    assert edited == "version: '0.2.0'\nname: pkg\n"
+
+
+def test_deeply_nested_key():
+    text = "a:\n  b:\n    version: 0.1.0\n  c:\n    version: 9.9.9\n"
+    edited = yaml_edit.replace_value(text, ["a", "b", "version"], "0.2.0")
+    assert edited == "a:\n  b:\n    version: '0.2.0'\n  c:\n    version: 9.9.9\n"
+
+
+def test_quoting_style_is_preserved():
+    assert yaml_edit.replace_value('version: "0.1.0"\n', ["version"], "0.2.0") == 'version: "0.2.0"\n'
+    assert yaml_edit.replace_value("version: '0.1.0'\n", ["version"], "0.2.0") == "version: '0.2.0'\n"
+
+
+def test_a_plain_value_is_quoted_so_its_type_cannot_change():
+    edited = yaml_edit.replace_value("version: 0.1.0\n", ["version"], "1.0")
+    assert edited == "version: '1.0'\n"
+    assert yaml.safe_load(edited)["version"] == "1.0"
+
+
+def test_quoted_key():
+    text = 'project:\n  "my.version": 0.1.0\n'
+    edited = yaml_edit.replace_value(text, ["project", "my.version"], "0.2.0")
+    assert edited == 'project:\n  "my.version": \'0.2.0\'\n'
+
+
+def test_a_hash_inside_a_quoted_value_is_not_treated_as_a_comment():
+    text = "version: '0.1.0#1'  # real comment\n"
+    edited = yaml_edit.replace_value(text, ["version"], "0.2.0")
+    assert edited == "version: '0.2.0'  # real comment\n"
+
+
+def test_keys_inside_a_sequence_are_not_matched():
+    text = "manifests:\n  - name: a\n    version: 0.1.0\n"
+    assert yaml_edit.replace_value(text, ["manifests", "version"], "0.2.0") is None
+
+
+def test_a_sequence_elsewhere_does_not_block_the_edit():
+    text = "manifests:\n  - name: a\n    version: 9.9.9\nproject:\n  version: 0.1.0\n"
+    edited = yaml_edit.replace_value(text, ["project", "version"], "0.2.0")
+    assert edited == text.replace("version: 0.1.0", "version: '0.2.0'")
+
+
+def test_a_key_inside_a_block_scalar_is_not_mistaken_for_an_assignment():
+    text = "readme: |\n  project:\n  version: 9.9.9\nversion: 0.1.0\n"
+    edited = yaml_edit.replace_value(text, ["version"], "0.2.0")
+    assert edited == text.replace("version: 0.1.0", "version: '0.2.0'")
+    assert "9.9.9" in edited
+
+
+def test_missing_key_returns_none():
+    assert yaml_edit.replace_value("project:\n  name: pkg\n", ["project", "version"], "0.2.0") is None
+
+
+def test_duplicate_matches_return_none():
+    text = "project:\n  version: 0.1.0\nproject:\n  version: 0.1.0\n"
+    assert yaml_edit.replace_value(text, ["project", "version"], "0.2.0") is None
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "project: {version: 0.1.0}\n",  # flow mapping
+        "project: &anchor\n  version: 0.1.0\n",  # anchor
+        "project:\n\tversion: 0.1.0\n",  # tab indentation
+        "project:\n  version: 0.1.0\n---\nproject:\n  version: 0.2.0\n",  # multiple documents
+        "just a scalar\n",  # not a mapping
+    ],
+)
+def test_unmodelled_yaml_returns_none(text):
+    assert yaml_edit.replace_value(text, ["project", "version"], "0.3.0") is None
+
+
+@pytest.mark.parametrize("version", ["1.0.0", "1.0.0+it's", '1.0.0+say"what"', "1.0.0.dev0"])
+def test_written_values_round_trip(version):
+    for original in ("version: 0.1.0\n", "version: '0.1.0'\n", 'version: "0.1.0"\n'):
+        edited = yaml_edit.replace_value(original, ["version"], version)
+        assert yaml.safe_load(edited)["version"] == version
+
+
+def test_a_version_containing_a_newline_is_refused():
+    assert yaml_edit.replace_value("version: 0.1.0\n", ["version"], "0.2.0\nname: evil") is None

--- a/test/providers/manifest/test_yaml_manfiest.py
+++ b/test/providers/manifest/test_yaml_manfiest.py
@@ -2,6 +2,8 @@ import pytest
 from unittest.mock import MagicMock, patch
 from pathlib import Path
 
+import yaml
+
 from vertagus.providers.manifest.yaml_manifest import YamlManifest
 
 
@@ -40,3 +42,51 @@ def test_update_version():
     assert manifest.version == "1.0.0"
     manifest.update_version("2.0.0", write=False)
     assert manifest.version == "2.0.0"
+
+
+_MANIFEST = """\
+# The package
+project:
+  name: pkg  # its name
+  version: 1.0.0
+
+  deps:
+    - click  # the CLI framework
+"""
+
+
+@pytest.fixture
+def yaml_file(tmp_path, patch_load_doc):
+    path = tmp_path / "manifest.yaml"
+    path.write_text(_MANIFEST)
+    return path
+
+
+def test_update_version_preserves_comments_and_formatting(yaml_file):
+    manifest = YamlManifest("test", str(yaml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"name": "pkg", "version": "1.0.0", "deps": ["click"]}}
+
+    manifest.update_version("2.0.0")
+
+    assert yaml_file.read_text() == _MANIFEST.replace("version: 1.0.0", "version: '2.0.0'")
+
+
+def test_update_version_falls_back_to_a_full_rewrite(yaml_file, caplog):
+    # The version is absent from the file, so it cannot be replaced in place.
+    yaml_file.write_text("project:\n  name: pkg\n")
+    manifest = YamlManifest("test", str(yaml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"name": "pkg"}}
+
+    manifest.update_version("2.0.0")
+
+    assert yaml.safe_load(yaml_file.read_text())["project"]["version"] == "2.0.0"
+    assert "may not be preserved" in caplog.text
+
+
+def test_update_version_leaves_the_file_alone_when_not_writing(yaml_file):
+    manifest = YamlManifest("test", str(yaml_file), loc=["project", "version"])
+    manifest._doc = {"project": {"version": "1.0.0"}}
+
+    manifest.update_version("2.0.0", write=False)
+
+    assert yaml_file.read_text() == _MANIFEST

--- a/uv.lock
+++ b/uv.lock
@@ -822,7 +822,7 @@ wheels = [
 
 [[package]]
 name = "vertagus"
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## The bug

`vertagus bump` writes TOML and YAML manifests by reserializing the parsed document. The parser has already thrown away everything that isn't data, so the rewrite discards every comment and blank line and reflows the file's collections, quoting and indentation. Bumping this project's own version produced a 51-line diff for a one-character change:

```diff
-version = "0.5.0.dev0"
+version = "0.5.0.dev1"
...
 ignore = [
-    "D100", # Ignore missing docstring in public module
-    "D101", # Ignore missing docstring in public class
+    "D100",
+    "D101",
```

For a project whose manifest carries commented configuration, that makes `vertagus bump` unusable in an automated workflow.

## The fix

Two new modules, `toml_edit.py` and `yaml_edit.py`, scan just enough of each format to find the span of text holding a value, so the version can be replaced in place and every other byte of the file left untouched. Both bumps are now one-line diffs.

They are written to refuse rather than guess. Unrecognized syntax, a missing key, or an ambiguous match returns `None`, and before anything is written the edited text is re-parsed and compared against the original data with only the version changed. Either check failing logs a warning and falls back to the previous whole-file rewrite, so the worst case is today's behavior. That write-verify-or-fall-back logic lives in the shared `InPlaceVersionWriter` mixin.

**TOML** — the scanner tracks quoting and comment state rather than matching lines, so a `version = "..."` inside a multi-line string, an inline table, or an array of tables is not mistaken for the real assignment.

**YAML** — models the block mappings that manifests are written in, and declines the rest: anchors, tags, flow collections, block scalars, multiple documents, and keys nested inside sequences (a vertagus `loc` names mapping keys only, so such a key is never a legitimate target). Replacements are always quoted, since unquoted `1.0` is a float to a YAML parser and a bump must not change a value's type; existing single- or double-quote style is preserved.

Before and after, on a real YAML manifest:

```yaml
# My package
project:
  name: pkg      # the name
  version: "1.0.0"     ->    version: "1.1.0"

  deps:
    - click  # cli
```

Previously this became a four-line file with no comments and realigned keys.

## Scope

JSON manifests are still rewritten in full. They have no comments to lose, so the cost is limited to reindentation — worth a follow-up but a much smaller problem.

## Tests

45 tests for the two scanners (comment and CRLF preservation, dotted/quoted/nested keys, multi-line and block scalars, inline tables and flow collections, arrays of tables and sequences, anchors, multiple documents, malformed input, quoting round-trips) and 6 for the manifest write paths including both fallbacks. 252 tests pass, ruff clean. Also smoke-tested end to end by bumping a real commented manifest of each format through the CLI.

Note: this branch and #65 both bump the version to `0.5.0.dev1` off `main`, so whichever merges second will want a re-bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)